### PR TITLE
Fixes for the build.

### DIFF
--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -6,7 +6,7 @@ function Settings() {
   this.settings_ = {};
   var storageKeys = {};
   for (var key in Settings.SETTINGS) {
-    this.settings_[key] = Settings.SETTINGS[key].default;
+    this.settings_[key] = Settings.SETTINGS[key]['default'];
     storageKeys['settings-' + key] = this.settings_[key];
   }
   chrome.storage.onChanged.addListener(this.onChanged_.bind(this));

--- a/build.py
+++ b/build.py
@@ -29,6 +29,7 @@ FILES = [
   'images/menu.svg',
   'images/search.svg',
   'js/background.js',
+  'js/util.js',
   'lib/jquery-1.8.3.min.js',
   'lib/ace/src-min-noconflict/ace.js',
   'lib/ace/src-min-noconflict/mode-c_cpp.js',


### PR DESCRIPTION
This fixes 2 issues:

1) build.py did not include util.js which is used by the background.js
file.

2) Closure was complaining about a property .default so I changed it to
['default'] which it didn't mind.
