### PR TITLE
Fixed issue #136, Fixed line number alignment diff between default/light <-> dark.

### DIFF
--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -42,6 +42,11 @@ body[theme="dark"] #settings-list select option {
   background: #e8e8e8;
 }
 
+.ace-text-dark .ace_gutter-cell {
+  padding: 0;
+  text-align: center;
+}
+
 .ace-text-dark .ace_scroller {
   background-color: #272822;
 }
@@ -78,10 +83,10 @@ body[theme="dark"] #settings-list select option {
 }
 
 .ace-text-dark .ace_marker-layer .ace_active_line {
-  background: #49483E;
+  background: #202020;
 }
 .ace-text-dark .ace_gutter_active_line {
-  background-color: #191916;
+  background-color: #272727;
 }
 
 .ace-text-dark .ace_marker-layer .ace_selected_word {


### PR DESCRIPTION
Added 45-49 to center align the gutter line numbers to match the default and light themes. After reviewing this further I'd like to right justify all themes to stay consistent with most editors.

Changed 86 and 89 to match Cloud9's Monokai theme which the Dark theme seems based on. This allows the .ace_selected_word to stay the same color and give the desired highlighting effect.
