### PR TITLE
Automatically set mode (syntax highlighting) when tab is renamed.

### DIFF
--- a/js/controllers/menu.js
+++ b/js/controllers/menu.js
@@ -59,6 +59,7 @@ MenuController.prototype.onDragOver_ = function(overItem, e) {
 
 MenuController.prototype.onTabRenamed = function(e, tab) {
   $('#tab' + tab.getId() + ' .filename').text(tab.getName());
+  this.tabs_.modeAutoSet(tab);
 };
 
 MenuController.prototype.onTabChange = function(e, tab) {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -320,6 +320,13 @@ Tabs.prototype.openFileEntry = function(entry) {
   }.bind(this));
 };
 
+Tabs.prototype.modeAutoSet = function(tab) {
+  var extension = tab.getExtension();
+  if (extension) {
+    this.editor_.setMode(tab.getSession(), extension);
+  }
+};
+
 Tabs.prototype.readFileToNewTab_ = function(entry, file) {
   var self = this;
   var reader = new FileReader();


### PR DESCRIPTION
This addresses the issue I opened a few minutes ago (https://github.com/GoogleChrome/text-app/issues/162).
