### PR TITLE
Added id during Window creation so that it remembers size and position

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -28,6 +28,7 @@ Background.prototype.ifShowFrame_ = function() {
 
 Background.prototype.newWindow = function() {
   var options = {
+    id: 'mainWindow',
     frame: (this.ifShowFrame_() ? 'chrome' : 'none'),
     minWidth: 400,
     minHeight: 400,


### PR DESCRIPTION
Joe Marini just wrote a blog post where he describes few shortcomings of this App at http://joemarini.blogspot.fr/2013/11/tools-for-developing-on-chromeos.html.

One of them is the fact that the Text App doesn't remember the window position or size.
By simply specifying an ID during the window creation process, the Chrome App Position and Size will be remembered auto-magically ;) 
See http://developer.chrome.com/apps/app_window.html#method-create
