### PR TITLE
Changed File Handler Title to Text Dev by default

### DIFF
--- a/build.py
+++ b/build.py
@@ -108,8 +108,10 @@ def process_manifest(out_dir, version):
   manifest = json.load(open(os.path.join(SOURCE_DIR, MANIFEST)))
   if USE_LOCALIZED_NAME:
     manifest['name'] = '__MSG_extName__'
+    manifest['file_handlers']['text']['title'] = '__MSG_extName__'
   else:
     manifest['name'] = APP_NAME
+    manifest['file_handlers']['text']['title'] = APP_NAME
   manifest['version'] = version
 
   if IS_APP:

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,7 @@
   ],
   "file_handlers": {
     "text": {
-      "title": "Text",
+      "title": "Text Dev",
       "icons": {"16": "icon/16x16.png", "96": "icon/96x96.png"},
       "types": ["application/javascript", "application/json", "application/x-shellscript", "application/xml", "text/*"],
       "extensions": ["asp", "aspx", "abc", "acgi", "aip", "asm", "c", "c++", "cc", "clj", "com", "coffee", "conf", "cpp", "cs", "csh", "css", "csv", "cxx", "def", "diff", "el", "ejs", "etx", "f", "f77", "f90", "flx", "for", "g", "gemspec", "go", "groovy", "h", "hh", "hlb", "hpp", "hs", "htc", "htm", "html", "htmls", "htt", "htx", "ics", "idc", "ifb", "jav", "java", "js", "json", "jsp", "ksh", "list", "log", "lsp", "lst", "lsx", "lua", "m", "man", "manifest", "mar", "mcf", "md", "mdoc", "me", "ms", "p", "pas", "patch", "pl", "pm", "pod", "py", "rake", "rb", "rexx", "roff", "rst", "rt", "rtf", "rtx", "ru", "s", "scm", "sdml", "sgm", "sgml", "sh", "shtml", "spc", "ssi", "st", "t", "talk", "tcl", "tcsh", "text", "textile", "tr", "tsv", "txt", "uil", "uni", "unis", "uri", "uris", "uu", "uue", "vcf", "vcs", "wml", "wmls", "wsc", "xml", "yaml", "yml", "zsh"]


### PR DESCRIPTION
Just noticed that when having Text and Text Dev installed on Chrome OS, it was impossible to know which one  would be used in the Files App.
