### PR TITLE
Always focus Text App when a file is opened

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -55,6 +55,7 @@ TextApp.prototype.openEntries = function(entries) {
   for (var i = 0; i < entries.length; i++) {
     this.tabs_.openFileEntry(entries[i]);
   }
+  this.windowController_.focus_();
 };
 
 TextApp.prototype.openNew = function() {

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -50,6 +50,10 @@ WindowController.prototype.close_ = function() {
   window.close();
 };
 
+WindowController.prototype.focus_ = function() {
+  window.chrome.app.window.current().focus();
+};
+
 WindowController.prototype.maximize_ = function() {
   var maximized = window.outerHeight == window.screen.availHeight &&
                   window.outerWidth == window.screen.availWidth;


### PR DESCRIPTION
The Text App should always been focused when we open a file from the Files App. Even if the file is already opened in the Files App while this one is in the background.
