### PR TITLE
Only show files the Text App can open on File Open

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -262,7 +262,14 @@ Tabs.prototype.closeCurrent = function() {
 };
 
 Tabs.prototype.openFile = function() {
-  Tabs.chooseEntry({'type': 'openWritableFile'}, this.openFileEntry.bind(this));
+  var manifestFileHandlers = chrome.runtime.getManifest().file_handlers.text;
+  var accepts = [{
+    'mimeTypes': manifestFileHandlers.types,
+    'extensions': manifestFileHandlers.extensions,
+  }];
+  Tabs.chooseEntry(
+      {'type': 'openWritableFile', 'accepts': accepts},
+      this.openFileEntry.bind(this));
 };
 
 Tabs.prototype.save = function(opt_tab, opt_close) {


### PR DESCRIPTION
We could also add a description like "Custom Files" in the Dropdown file open dialog. It works great without on Chrome OS since it generates something like ".txt, .html, etc". However, it kinda sucks on Ubuntu as you can see below.

![screenshot from 2013-12-04 13 34 28](https://f.cloud.github.com/assets/634478/1673106/dd640a64-5ce0-11e3-9702-073d7e8a5278.png)
Let me know what you think.
If we want to add a description string, I would like to start internationalizing the Text App.

BUG=https://github.com/GoogleChrome/text-app/issues/154
