### PR TITLE
Fixed appWindow ID for multiple created windows

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -27,8 +27,9 @@ Background.prototype.ifShowFrame_ = function() {
 };
 
 Background.prototype.newWindow = function() {
+  var appWindowId = 'appWindow' + this.windows_.length;
   var options = {
-    id: 'mainWindow',
+    id: appWindowId,
     frame: (this.ifShowFrame_() ? 'chrome' : 'none'),
     minWidth: 400,
     minHeight: 400,


### PR DESCRIPTION
I didn't know at the time we could create multiple windows within the Text App. 
This change addresses the issue and remembers where were positioned all closed windows.

TEST=
Open three windows with <Ctrl>+<Shift>+n
Move them
Close them
Reopen three windows, they should be positioned where they were before being closed.
