### PR TITLE
Removed useless permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,10 +24,7 @@
     }
   },
   "permissions": [
-    "clipboardRead",
-    "clipboardWrite",
     "storage",
-    "unlimitedStorage",
     {"fileSystem": ["write"]}
   ],
   "file_handlers": {


### PR DESCRIPTION
`clipboardRead` and `clipboardWrite` permissions don't seem to be used at all in the Text App. I didn't find any references to `execCommand` or to `clipboardData`.

`unlimitedStorage` permission is useful to get more 5 MB of local storage which is not what we need for now since the only thing we save are the settings.

http://developer.chrome.com/extensions/declare_permissions.html
