### PR TITLE
Switched error message to loading message

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -83,6 +83,10 @@
     "message": "Search",
     "description":"The button text to search."
   },
+  "errorTitle": {
+    "message": "Error",
+    "description":"The error text displayed in the filename title bar."
+  },
   "loadingTitle": {
     "message": "Loading...",
     "description":"The text displayed in the filename title bar when file loads."

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
         <div class="icon-button" id="toggle-sidebar" i18n-values="title:openSidebarButton"></div>
         <div class="icon-button" id="search-button" i18n-values="title:searchButton"></div>
         <input type="search" id="search-input">
-        <div id="title-filename" i18n-content="loadingTitle"></div>
+        <div id="title-filename" i18n-content="errorTitle"></div>
         <div class="icon-button" id="window-maximize" i18n-values="title:maximizeButton"></div>
         <div class="icon-button" id="window-close" i18n-values="title:closeButton"></div>
       </header>

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -9,6 +9,8 @@ function WindowController(editor, settings) {
   $('#window-maximize').click(this.maximize_.bind(this));
   $('#toggle-sidebar').click(this.toggleSidebar_.bind(this));
   $('#sidebar-resizer').mousedown(this.resizeStart_.bind(this));
+  $(document).bind('filesystemerror', this.onFileSystemError.bind(this));
+  $(document).bind('loadingfile', this.onLoadingFile.bind(this));
   $(document).bind('switchtab', this.onChangeTab_.bind(this));
   $(document).bind('tabchange', this.onTabChange_.bind(this));
   $(document).bind('tabpathchange', this.onTabPathChange.bind(this));
@@ -80,6 +82,14 @@ WindowController.prototype.toggleSidebar_ = function() {
   }
   this.editor_.focus();
   setTimeout(function() {$.event.trigger('resize');}, 200);
+};
+
+WindowController.prototype.onLoadingFile = function(e) {
+  $('#title-filename').text(chrome.i18n.getMessage('loadingTitle'));
+};
+
+WindowController.prototype.onFileSystemError = function(e) {
+  $('#title-filename').text(chrome.i18n.getMessage('errorTitle'));
 };
 
 WindowController.prototype.onChangeTab_ = function(e, tab) {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -402,6 +402,7 @@ Tabs.prototype.modeAutoSet = function(tab) {
 };
 
 Tabs.prototype.readFileToNewTab_ = function(entry, file) {
+  $.event.trigger('loadingfile');
   var self = this;
   var reader = new FileReader();
   reader.onerror = util.handleFSError;

--- a/js/util.js
+++ b/js/util.js
@@ -22,6 +22,7 @@ util.fsErrorStr = function(e) {
 }
 
 util.handleFSError = function(e) {
+  $.event.trigger('filesystemerror');
   console.warn('FS Error:', util.fsErrorStr(e), e);
 };
 


### PR DESCRIPTION
Open a huge file (an image for instance) in the Text App and look at the `error` message.
I rather see a `Loading...` message instead.

What do you think?

![screenshot from 2013-12-23 14 59 44](https://f.cloud.github.com/assets/634478/1800989/a4e59514-6bda-11e3-9d87-18a86c4a4253.png)
