### PR TITLE
Added 'print.css' to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -20,6 +20,7 @@ FILES = [
   'index.html',
   '_locales/en/messages.json',
   'css/app.css',
+  'css/print.css',
   'css/theme-dark.css',
   'css/theme-default.css',
   'css/theme-light.css',


### PR DESCRIPTION
I just noticed while inspecting the current Text.app on the Webstore that `print.css` file was missing. It looks like I forgot to include it in `build.py`.

This CL addresses the issue.

TBR=@eterevsky

![screenshot 2014-11-18 at 4 01 02 pm](https://cloud.githubusercontent.com/assets/634478/5089502/2073fcf6-6f3c-11e4-9782-e3f90847e993.png)
