### PR TITLE
Access Closure Compiler via HTTPS (Chromium issue #760416).

### DIFF
--- a/build.py
+++ b/build.py
@@ -158,7 +158,7 @@ def print_errors(errors, js_files):
     if error['file'].lower().find('externs') >= 0:
       filename = error['file']
     else:
-      fileno = int(error['file'][6:])
+      fileno = int(error['file'][6:]) - 1 # Debug flag is file 0
       filename = js_files[fileno]
     if 'error' in error:
       text = error['error']

--- a/build.py
+++ b/build.py
@@ -53,7 +53,7 @@ TARGET_JS_INCLUDE = ('<script src="' + TARGET_JS + '" type="text/javascript">'
                      '</script>')
 JS_INCLUDES = re.compile(r'(<!-- JS -->.*<!-- /JS -->)', flags=re.M | re.S)
 JS_SRC = re.compile(r'<script src="([^"]*)" type="text/javascript">')
-CLOSURE_URL = 'http://closure-compiler.appspot.com/compile'
+CLOSURE_URL = 'https://closure-compiler.appspot.com/compile'
 BACKGROUND_EXTERNS = os.path.join(SOURCE_DIR, 'js/externs.js')
 JS_EXTERNS = None
 EXTERNS_URLS = [


### PR DESCRIPTION
Currently, the Closure Compiler web service is accessed via HTTP.  If the request is intercepted, the compiled Javascript may be replaced with something else.  This patch uses HTTPS instead, which on modern versions of Python also validates certificates.

Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=760416

The second commit fixes an issue where the debug stanza would cause warnings and errors to be raised about the wrong file number.