### PR TITLE
Fix build errors

### DIFF
--- a/build.py
+++ b/build.py
@@ -158,7 +158,7 @@ def print_errors(errors, js_files):
     if error['file'].lower().find('externs') >= 0:
       filename = error['file']
     else:
-      fileno = int(error['file'][6:])
+      fileno = int(error['file'][6:]) - 1
       filename = js_files[fileno]
     if 'error' in error:
       text = error['error']

--- a/build.py
+++ b/build.py
@@ -53,7 +53,7 @@ TARGET_JS_INCLUDE = ('<script src="' + TARGET_JS + '" type="text/javascript">'
                      '</script>')
 JS_INCLUDES = re.compile(r'(<!-- JS -->.*<!-- /JS -->)', flags=re.M | re.S)
 JS_SRC = re.compile(r'<script src="([^"]*)" type="text/javascript">')
-CLOSURE_URL = 'http://closure-compiler.appspot.com/compile'
+CLOSURE_URL = 'https://closure-compiler.appspot.com/compile'
 BACKGROUND_EXTERNS = os.path.join(SOURCE_DIR, 'js/externs.js')
 JS_EXTERNS = None
 EXTERNS_URLS = [


### PR DESCRIPTION
Fixes 2 build errors in the build.py script:
1. Changes closure url to use https instead of https to fix 405 build error
2. Fixes off by 1 error when printing filenames for error messages and warning messages. This prevents an IndexError when there is an error or warning occurs in the last file.