### PR TITLE
Center text inside dialog box.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -547,6 +547,7 @@ input[type=search]:focus {
 .dialog-text {
   display: -webkit-box;
   font-size: 15px;
+  text-align: center;
 }
 
 .dialog-buttons {


### PR DESCRIPTION
This ensures text is centered in the dialog when text wraps.

Before patch:
![screenshot from 2018-04-24 13-03-06](https://user-images.githubusercontent.com/6046079/39163929-28108686-47c0-11e8-89fe-3fa2ed22054d.png)
After patch:
![screenshot from 2018-04-24 13-06-36](https://user-images.githubusercontent.com/6046079/39163957-5a1a3cf8-47c0-11e8-8829-e3254dee05e6.png)
