### PR TITLE
Add filename to saveFilePrompt.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -158,8 +158,8 @@
     "description":"The button text which says 'Cancel'."
   },
   "saveFilePrompt": {
-    "message": "Do you want to save the file before closing?",
-    "description":"The text which prompts user if they want to save file before closing it."
+    "message": " has been modified. Do you want to save it before closing?",
+    "description":"The text which prompts user if they want to save file before closing it (preceded by the file name)."
   },
   "okDialogButton": {
     "message": "OK",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -158,8 +158,14 @@
     "description":"The button text which says 'Cancel'."
   },
   "saveFilePrompt": {
-    "message": " has been modified. Do you want to save it before closing?",
-    "description":"The text which prompts user if they want to save file before closing it (preceded by the file name)."
+    "message": "$filename$ has been modified. Do you want to save it before closing?",
+    "description":"The text which prompts user if they want to save file before closing it.",
+    "placeholders": {
+      "filename": {
+        "content": "$1",
+        "example": "index.html"
+      }
+    }
   },
   "okDialogButton": {
     "message": "OK",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -163,7 +163,7 @@
     "placeholders": {
       "filename": {
         "content": "$1",
-        "example": "index.html"
+        "example": "file.txt"
       }
     }
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -158,8 +158,14 @@
     "description":"O texto do botão que diz 'Cancelar'."
   },
   "saveFilePrompt": {
-    "message": "Você deseja salvar o arquivo antes de fechar?",
-    "description":"O texto que é mostrado ao usuário, se ele quer salvar o arquivo antes de fechá-lo."
+    "message": "O arquivo $filename$ foi modificado. Quer salvá-lo antes de fechar?",
+    "description":"O texto que é mostrado ao usuário, se ele quer salvar o arquivo antes de fechá-lo.",
+    "placeholders": {
+      "filename": {
+        "content": "$1",
+        "example": "index.html"
+      }
+    }
   },
   "okDialogButton": {
     "message": "OK",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -163,7 +163,7 @@
     "placeholders": {
       "filename": {
         "content": "$1",
-        "example": "index.html"
+        "example": "arquivo.txt"
       }
     }
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -109,7 +109,13 @@
    },
    "saveFilePrompt": {
       "description": "The text which prompts user if they want to save file before closing it.",
-      "message": "保存后退出?"
+      "message": "文件“$filename$”已被修改。是否要在保存后再将其关闭？",
+      "placeholders": {
+         "filename": {
+            "content": "$1",
+            "example": "index.html"
+         }
+      }
    },
    "searchButton": {
       "description": "The button text to search.",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -113,7 +113,7 @@
       "placeholders": {
          "filename": {
             "content": "$1",
-            "example": "index.html"
+            "example": "file.txt"
          }
       }
    },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -109,7 +109,13 @@
    },
    "saveFilePrompt": {
       "description": "The text which prompts user if they want to save file before closing it.",
-      "message": "保存後退出?"
+      "message": "$filename$ 已經過修改，你要先儲存變更再關閉檔案嗎？",
+      "placeholders": {
+         "filename": {
+            "content": "$1",
+            "example": "index.html"
+         }
+      }
    },
    "searchButton": {
       "description": "The button text to search.",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -113,7 +113,7 @@
       "placeholders": {
          "filename": {
             "content": "$1",
-            "example": "index.html"
+            "example": "file.txt"
          }
       }
    },

--- a/css/app.css
+++ b/css/app.css
@@ -534,19 +534,16 @@ input[type=search]:focus {
 .dialog-window {
   background-color: #F5F5F5;
   border: 1px solid rgba(0,0,0,0.15);
-  -webkit-box-align: center;
-  -webkit-box-orient: vertical;
-  -webkit-box-pack: center;
   box-shadow: rgba(0,0,0,0.13) 0px 4px 30px;
-  display: -webkit-box;
   max-width: 50%;
   opacity: 1.0;
   padding: 24px;
 }
 
 .dialog-text {
-  display: -webkit-box;
   font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .dialog-buttons {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -263,6 +263,9 @@ Tabs.prototype.close = function(tabId) {
 
   var tab = this.tabs_[i];
   var filename = tab.getEntry().name;
+  if (filename.length > 25) {
+    filename = filename.slice(0, 22).concat('...');
+  }
 
   if (!tab.isSaved()) {
     this.dialogController_.setText(

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -262,10 +262,11 @@ Tabs.prototype.close = function(tabId) {
   }
 
   var tab = this.tabs_[i];
+  var filename = tab.getEntry().name;
 
   if (!tab.isSaved()) {
     this.dialogController_.setText(
-        chrome.i18n.getMessage('saveFilePrompt'));
+        filename + chrome.i18n.getMessage('saveFilePrompt'));
     this.dialogController_.resetButtons();
     this.dialogController_.addButton('yes',
         chrome.i18n.getMessage('yesDialogButton'));

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -269,7 +269,7 @@ Tabs.prototype.close = function(tabId) {
 
   if (!tab.isSaved()) {
     this.dialogController_.setText(
-        filename + chrome.i18n.getMessage('saveFilePrompt'));
+        chrome.i18n.getMessage('saveFilePrompt', filename));
     this.dialogController_.resetButtons();
     this.dialogController_.addButton('yes',
         chrome.i18n.getMessage('yesDialogButton'));

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -262,7 +262,7 @@ Tabs.prototype.close = function(tabId) {
   }
 
   var tab = this.tabs_[i];
-  var filename = tab.getEntry().name;
+  var filename = tab.getName();
   if (filename.length > 25) {
     filename = filename.slice(0, 22).concat('...');
   }

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -262,10 +262,7 @@ Tabs.prototype.close = function(tabId) {
   }
 
   var tab = this.tabs_[i];
-  var filename = tab.getName();
-  if (filename.length > 25) {
-    filename = filename.slice(0, 22).concat('...');
-  }
+  var filename = tab.getEntry().name;
 
   if (!tab.isSaved()) {
     this.dialogController_.setText(

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -262,11 +262,10 @@ Tabs.prototype.close = function(tabId) {
   }
 
   var tab = this.tabs_[i];
-  var filename = tab.getEntry().name;
 
   if (!tab.isSaved()) {
     this.dialogController_.setText(
-        chrome.i18n.getMessage('saveFilePrompt', filename));
+        chrome.i18n.getMessage('saveFilePrompt', tab.getName()));
     this.dialogController_.resetButtons();
     this.dialogController_.addButton('yes',
         chrome.i18n.getMessage('yesDialogButton'));


### PR DESCRIPTION
Note that this is a draft patch, I would like a first pass review please.

I am blocked on getting translated messages for the messages files, which is required before this patch can be merged.

I'm open to changing the design for the maximum length of file name. Currently it looks like this for long file names when the window is resized to the smallest possible size:
![screenshot from 2018-04-24 14-47-44](https://user-images.githubusercontent.com/6046079/39166775-d8e0339a-47ce-11e8-9d87-20e1f6490923.png)
