### PR TITLE
Clear search only when focus leaves search container.

### DIFF
--- a/js/controllers/search.js
+++ b/js/controllers/search.js
@@ -9,7 +9,7 @@ function SearchController(search) {
   $('#search-input').keydown(this.onKeydown_.bind(this));
   $('#search-next-button').click(this.onFindNext_.bind(this));
   $('#search-previous-button').click(this.onFindPrevious_.bind(this));
-  $('body').focusin(this.onChangeFocus_.bind(this));
+  $('.search-container').focusout(this.onFocusoutSearch_.bind(this));
 }
 
 SearchController.prototype.updateSearchCount_ = function() {
@@ -44,15 +44,13 @@ SearchController.prototype.onSearchButton_ = function() {
   return false;
 };
 
-SearchController.prototype.onChangeFocus_ = function() {
-  if (document.activeElement === document.body ||
-      $(document.activeElement).parents('.search-container').length) {
-    return;
+SearchController.prototype.onFocusoutSearch_ = function(e) {
+  if (!e.relatedTarget.closest('.search-container')) {
+    $('#search-input').val('');
+    $('#search-counting').text('');
+    $('header').removeClass('search-active');
+    this.search_.clear();
   }
-  $('#search-input').val('');
-  $('#search-counting').text('');
-  $('header').removeClass('search-active');
-  this.search_.clear();
 };
 
 SearchController.prototype.onChange_ = function() {

--- a/js/controllers/search.js
+++ b/js/controllers/search.js
@@ -9,7 +9,7 @@ function SearchController(search) {
   $('#search-input').keydown(this.onKeydown_.bind(this));
   $('#search-next-button').click(this.onFindNext_.bind(this));
   $('#search-previous-button').click(this.onFindPrevious_.bind(this));
-  $('.search-container').focusout(this.onFocusoutSearch_.bind(this));
+  $('.search-container').focusout(this.deactivateSearch_.bind(this));
 }
 
 SearchController.prototype.updateSearchCount_ = function() {
@@ -44,7 +44,7 @@ SearchController.prototype.onSearchButton_ = function() {
   return false;
 };
 
-SearchController.prototype.onFocusoutSearch_ = function(e) {
+SearchController.prototype.deactivateSearch_ = function(e) {
   if (!e.relatedTarget.closest('.search-container')) {
     $('#search-input').val('');
     $('#search-counting').text('');


### PR DESCRIPTION
Clear search only when focus leaves the search container, rather than whenever focus changes to anywhere outside of the search container.

Fixes #282, which is partially caused by a [bug on CodeMirror](https://github.com/codemirror/CodeMirror/issues/5406)