### PR TITLE
Warn user of all tabs with unsaved progress when window is closed.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -32,7 +32,7 @@ TextApp.prototype.init = function() {
   this.searchController_ = new SearchController(this.editor_.getSearch());
   this.settingsController_ = new SettingsController(this.settings_);
   this.windowController_ = new WindowController(
-      this.editor_, this.settings_, this.analytics_);
+      this.editor_, this.settings_, this.analytics_, this.tabs_);
   this.hotkeysController_ = new HotkeysController( this.windowController_,
       this.tabs_, this.editor_, this.settings_, this.analytics_);
 

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -1,11 +1,11 @@
 /**
  * @constructor
  */
-function WindowController(editor, settings, analytics) {
+function WindowController(editor, settings, analytics, tabs) {
   this.editor_ = editor;
   this.settings_ = settings;
   this.analytics_ = analytics;
-  this.currentTab_ = null;
+  this.tabs_ = tabs;
   $('#window-close').click(this.close_.bind(this));
   $('#window-minimize').click(this.minimize_.bind(this));
   $('#window-maximize').click(this.maximize_.bind(this));
@@ -53,7 +53,7 @@ WindowController.prototype.setTheme = function(theme) {
 };
 
 WindowController.prototype.close_ = function() {
-  window.close();
+  this.tabs_.promptAllUnsaved(window.close);
 };
 
 WindowController.prototype.focus_ = function() {
@@ -103,7 +103,6 @@ WindowController.prototype.onFileSystemError = function(e) {
 };
 
 WindowController.prototype.onChangeTab_ = function(e, tab) {
-  this.currentTab_ = tab;
   $('#title-filename').text(tab.getName());
   this.onTabChange_();
 };
@@ -113,7 +112,7 @@ WindowController.prototype.onTabPathChange = function(e, tab) {
 };
 
 WindowController.prototype.onTabChange_ = function(e, tab) {
-  if (this.currentTab_.isSaved()) {
+  if (this.tabs_.getCurrentTab().isSaved()) {
     $('#title-filename').removeClass('unsaved');
   } else {
     $('#title-filename').addClass('unsaved');

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -318,35 +318,29 @@ Tabs.prototype.promptAllUnsaved = function(callback) {
 }
 
 Tabs.prototype.promptAllUnsavedFromIndex_ = function(i, callback) {
-  if (this.tabs_.length > i) {
-    var tab = this.tabs_[i];
-    if (tab.isSaved()) {
-      this.promptAllUnsavedFromIndex_(i + 1, callback);
-    } else {
-      this.showTab(this.tabs_[i].getId());
-      this.promptSave_(tab, function(answer) {
-        if (answer === 'yes') {
-          this.save(tab, false /* close */);
-        } else if (answer === 'cancel') {
-          return;
-        }
-        this.promptAllUnsavedFromIndex_(i + 1, callback);
-      }.bind(this));
-    }
-  }
-  else {
+  if (i >= this.tabs_.length) {
     callback();
+    return;
+  }
+  var tab = this.tabs_[i];
+  if (tab.isSaved()) {
+    this.promptAllUnsavedFromIndex_(i + 1, callback);
+  } else {
+    this.showTab(this.tabs_[i].getId());
+    this.promptSave_(tab, function(answer) {
+      if (answer === 'yes') {
+        this.save(tab, false /* close */);
+      } else if (answer === 'cancel') {
+        return;
+      }
+      this.promptAllUnsavedFromIndex_(i + 1, callback);
+    }.bind(this));
   }
 }
 
 Tabs.prototype.promptSave_ = function(tab, callbackShowDialog) {
-  var filename = tab.getName();
-  if (filename.length > 25) {
-    filename = filename.slice(0, 22).concat('...');
-  }
-
   this.dialogController_.setText(
-      chrome.i18n.getMessage('saveFilePrompt', filename));
+      chrome.i18n.getMessage('saveFilePrompt', tab.getName()));
   this.dialogController_.resetButtons();
   this.dialogController_.addButton('yes',
       chrome.i18n.getMessage('yesDialogButton'));

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -315,13 +315,14 @@ Tabs.prototype.openFiles = function() {
  */
 Tabs.prototype.promptAllUnsaved = function(callback) {
   this.promptAllUnsavedFromIndex_(0, callback);
-}
+};
 
 Tabs.prototype.promptAllUnsavedFromIndex_ = function(i, callback) {
   if (i >= this.tabs_.length) {
     callback();
     return;
   }
+
   var tab = this.tabs_[i];
   if (tab.isSaved()) {
     this.promptAllUnsavedFromIndex_(i + 1, callback);
@@ -336,7 +337,7 @@ Tabs.prototype.promptAllUnsavedFromIndex_ = function(i, callback) {
       this.promptAllUnsavedFromIndex_(i + 1, callback);
     }.bind(this));
   }
-}
+};
 
 Tabs.prototype.promptSave_ = function(tab, callbackShowDialog) {
   this.dialogController_.setText(

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -177,7 +177,7 @@ Tabs.prototype.getTabById = function(id) {
   return null;
 };
 
-Tabs.prototype.getCurrentTab = function(id) {
+Tabs.prototype.getCurrentTab = function() {
   return this.currentTab_;
 };
 
@@ -264,24 +264,11 @@ Tabs.prototype.close = function(tabId) {
   var tab = this.tabs_[i];
 
   if (!tab.isSaved()) {
-    this.dialogController_.setText(
-        chrome.i18n.getMessage('saveFilePrompt', tab.getName()));
-    this.dialogController_.resetButtons();
-    this.dialogController_.addButton('yes',
-        chrome.i18n.getMessage('yesDialogButton'));
-    this.dialogController_.addButton('no',
-        chrome.i18n.getMessage('noDialogButton'));
-    this.dialogController_.addButton('cancel',
-        chrome.i18n.getMessage('cancelDialogButton'));
-    this.dialogController_.show(function(answer) {
+    this.promptSave_(tab, function(answer) {
       if (answer === 'yes') {
         this.save(tab, true /* close */);
-        return;
-      }
-
-      if (answer === 'no') {
+      } else if (answer === 'no') {
         this.closeTab_(tab);
-        return;
       }
     }.bind(this));
   } else {
@@ -320,6 +307,54 @@ Tabs.prototype.openFiles = function() {
   this.chooseEntries(
       {'type': 'openWritableFile'},
       this.openFileEntry.bind(this));
+};
+
+/**
+ * @param {function()} callback
+ * Invoke the save dialog for all tabs with unsaved progress. Does not close any tabs.
+ */
+Tabs.prototype.promptAllUnsaved = function(callback) {
+  this.promptAllUnsavedFromIndex_(0, callback);
+}
+
+Tabs.prototype.promptAllUnsavedFromIndex_ = function(i, callback) {
+  if (this.tabs_.length > i) {
+    var tab = this.tabs_[i];
+    if (tab.isSaved()) {
+      this.promptAllUnsavedFromIndex_(i + 1, callback);
+    } else {
+      this.showTab(this.tabs_[i].getId());
+      this.promptSave_(tab, function(answer) {
+        if (answer === 'yes') {
+          this.save(tab, false /* close */);
+        } else if (answer === 'cancel') {
+          return;
+        }
+        this.promptAllUnsavedFromIndex_(i + 1, callback);
+      }.bind(this));
+    }
+  }
+  else {
+    callback();
+  }
+}
+
+Tabs.prototype.promptSave_ = function(tab, callbackShowDialog) {
+  var filename = tab.getName();
+  if (filename.length > 25) {
+    filename = filename.slice(0, 22).concat('...');
+  }
+
+  this.dialogController_.setText(
+      chrome.i18n.getMessage('saveFilePrompt', filename));
+  this.dialogController_.resetButtons();
+  this.dialogController_.addButton('yes',
+      chrome.i18n.getMessage('yesDialogButton'));
+  this.dialogController_.addButton('no',
+      chrome.i18n.getMessage('noDialogButton'));
+  this.dialogController_.addButton('cancel',
+      chrome.i18n.getMessage('cancelDialogButton'));
+  this.dialogController_.show(callbackShowDialog);
 };
 
 Tabs.prototype.save = function(opt_tab, opt_close) {


### PR DESCRIPTION
This patch iterates through each open tab and prompts the user with the save file dialog for each tab with unsaved progress before closing the window. This fixes #273.

Re-re-upload cause patch dependencies and rebasing apparently disconnected the branch from the previous PR at https://github.com/GoogleChromeLabs/text-app/pull/329 :\