### PR TITLE
Deactivate search bar when focus leaves for element cannot receive focus.

### DIFF
--- a/js/controllers/search.js
+++ b/js/controllers/search.js
@@ -45,7 +45,8 @@ SearchController.prototype.onSearchButton_ = function() {
 };
 
 SearchController.prototype.deactivateSearch_ = function(e) {
-  if (!e.relatedTarget.closest('.search-container')) {
+  // relatedTarget is null if the element clicked on can't receive focus
+  if (!e.relatedTarget || !e.relatedTarget.closest('.search-container')) {
     $('#search-input').val('');
     $('#search-counting').text('');
     $('header').removeClass('search-active');


### PR DESCRIPTION
Example use case: search is active and user clicks on side bar (which cannot receive focus). 

Previously this would throw an uncaught error and the search bar would not deactivate (where deactivation means clearing the search query, hiding the search bar, and showing the search button). Deactivation is supposed to happen whenever focus leaves the search bar, and works correctly when the user clicks on the text area (which can receive focus).