### PR TITLE
Add metric to track 'Always on top' feature.

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -48,9 +48,9 @@ Analytics.prototype.setEnabled = function(enabled) {
 };
 
 Analytics.prototype.onSettingsChange_ = function(e, key, value) {
-  if (key === 'analytics')
+  if (key === 'analytics') {
     this.setEnabled(value);
-  else if (key === 'alwaysontop') {
+  } else if (key === 'alwaysontop') {
     if (value)
       this.reportEvent('action', 'Always on top: on');
     else

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -50,7 +50,7 @@ Analytics.prototype.setEnabled = function(enabled) {
 Analytics.prototype.onSettingsChange_ = function(e, key, value) {
   if (key === 'analytics')
     this.setEnabled(value);
-  else if (this.enabled_ && key === 'alwaysontop') {
+  else if (key === 'alwaysontop') {
     if (value)
       this.reportEvent('action', 'Always on top: on');
     else

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -50,4 +50,10 @@ Analytics.prototype.setEnabled = function(enabled) {
 Analytics.prototype.onSettingsChange_ = function(e, key, value) {
   if (key === 'analytics')
     this.setEnabled(value);
+  else if (this.enabled_ && key === 'alwaysontop') {
+    if (value)
+      this.reportEvent('action', 'Always on top: on');
+    else
+      this.reportEvent('action', 'Always on top: off')
+  }
 };

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -54,6 +54,6 @@ Analytics.prototype.onSettingsChange_ = function(e, key, value) {
     if (value)
       this.reportEvent('action', 'Always on top: on');
     else
-      this.reportEvent('action', 'Always on top: off')
+      this.reportEvent('action', 'Always on top: off');
   }
 };


### PR DESCRIPTION
Add metric to report each time a user turns 'Always on top' feature on/off. At the moment there is a metric to log all settings including this once at the beginning of each session. This metric is intended to get a more fine grained idea of when the feature is used briefly within a session.