### PR TITLE
Delete unused dark theme css.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -313,18 +313,6 @@ header {
   -webkit-user-select: none;
 }
 
-header.dark {
-  background-color: #333;
-}
-
-header.dark #title-filename {
-  color: #F5F5F5;
-}
-
-header.dark .icon-button {
-  -webkit-filter: invert(100%);
-}
-
 .icon-button {
   -webkit-app-region: no-drag;
   background-position: center center;


### PR DESCRIPTION
Delete unused dark theme css. Since [09d6894](https://github.com/GoogleChromeLabs/text-app/commit/09d6894a03143813d9c95d4dbcf054013aba4021) changing the theme has changed the 'theme' attribute on the 'body' element, rather than the 'theme' class on the 'header' element. 