### PR TITLE
Deleted unused css on class .sidebar-open.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -336,12 +336,6 @@ header {
   background-image: url('../images/menu.svg');
 }
 
-.sidebar-open #toggle-sidebar {
-  border: 1px solid rgba(0,0,0,0.16);
-  color: #333;
-  opacity: 0.8;
-}
-
 #search-button {
   background-image: url('../images/search.svg');
   background-size: 22px;


### PR DESCRIPTION
The .sidebar-open class stopped being used in [this PR](https://github.com/GoogleChromeLabs/text-app/commit/1913b5cbcd1a0af514684bd9b93d5e62175278ea).