### PR TITLE
Change build script to compile in ES6 mode.

### DIFF
--- a/build.py
+++ b/build.py
@@ -175,7 +175,7 @@ def compile_js(out_path, js_files, level, externs):
 
   params = [
       ('compilation_level', level),
-      ('language', 'ECMASCRIPT5'),
+      ('language', 'ECMASCRIPT6'),
       ('output_format', 'json'),
       ('output_info', 'statistics'),
       ('output_info', 'warnings'),


### PR DESCRIPTION
Part of #353. This will allow use of ES6 features without causing build errors. 

This was unblocked in #362 when CodeMirror library was updated.