### PR TITLE
Remove all assumptions about closure response keys being present

### DIFF
--- a/build.py
+++ b/build.py
@@ -157,17 +157,24 @@ def process_index(out_dir):
 
 def print_errors(errors, js_files):
   for error in errors:
-    if error['file'].lower().find('externs') >= 0:
-      filename = error['file']
-    else:
-      fileno = int(error['file'][6:]) - 1
+    filename = error.get('file', '')
+    if not filename:
+      filename = missing_key_string('file')
+    elif filename.lower().find('externs') < 0:
+      fileno = int(filename[6:]) - 1
       filename = js_files[fileno]
     if 'error' in error:
       text = error['error']
-    else:
+    elif 'warning' in error:
       text = error['warning']
-    print(filename + ':' + str(error['lineno']) + ' ' + text)
-    print(error['line'])
+    else:
+      text = missing_key_string('error/warning')
+    print(filename + ':' + str(error.get('lineno', missing_key_string('lineno'))) + ' ' + text)
+    print (error.get('line', missing_key_string('line')))
+
+
+def missing_key_string(key):
+  return '[\'' + key + '\' key missing]'
 
 
 def compile_js(out_path, js_files, level, externs):
@@ -225,7 +232,10 @@ def compile_js(out_path, js_files, level, externs):
 
   print('Writing', out_path)
   os.makedirs(os.path.dirname(out_path), exist_ok=True)
-  open(out_path, 'w').write(result['compiledCode'])
+  if result.get('compiledCode'):
+    open(out_path, 'w').write(result.get('compiledCode'))
+  else:
+    print(missing_key_string('compiledCode'))
 
 
 def main():

--- a/build.py
+++ b/build.py
@@ -159,7 +159,7 @@ def print_errors(errors, js_files):
   for error in errors:
     filename = error.get('file', '')
     if not filename:
-      filename = missing_key_string('file')
+      filename = get_missing_key_msg('file')
     elif filename.lower().find('externs') < 0:
       fileno = int(filename[6:]) - 1
       filename = js_files[fileno]
@@ -168,12 +168,12 @@ def print_errors(errors, js_files):
     elif 'warning' in error:
       text = error['warning']
     else:
-      text = missing_key_string('error/warning')
-    print(filename + ':' + str(error.get('lineno', missing_key_string('lineno'))) + ' ' + text)
-    print (error.get('line', missing_key_string('line')))
+      text = get_missing_key_msg('error/warning')
+    print(filename + ':' + str(error.get('lineno', get_missing_key_msg('lineno'))) + ' ' + text)
+    print (error.get('line', get_missing_key_msg('line')))
 
 
-def missing_key_string(key):
+def get_missing_key_msg(key):
   return '[\'' + key + '\' key missing]'
 
 
@@ -235,7 +235,9 @@ def compile_js(out_path, js_files, level, externs):
   if result.get('compiledCode'):
     open(out_path, 'w').write(result.get('compiledCode'))
   else:
-    print(missing_key_string('compiledCode'))
+    print(
+      'Fatal build error: '
+      'compiledCode key missing from Closure response object')
 
 
 def main():


### PR DESCRIPTION
Removes assumptions in build script about what keys are present in closure response object to prevent crashes when these assumptions are violated. E.g. a crash like this was caused in #374 where material design library warnings were missing the ‘line’ key. Now when keys are missing that information in the build output is replaced by a warning that the key is missing.

[Diff](https://gist.github.com/BugsNash/337cfc2f9a74aeef9bb43c0c7f8a169c/revisions) of build output of this script on #374