### PR TITLE
Fix build regression

### DIFF
--- a/build.py
+++ b/build.py
@@ -16,7 +16,8 @@ BASE_DIR = os.path.dirname(sys.argv[0])
 SOURCE_DIR = BASE_DIR
 BUILD_DIR = os.path.join(BASE_DIR, 'build')
 
-FILES = [
+# These files will be copied into the newly built directory as is.
+FILES_TO_COPY = [
   'index.html',
   '_locales/en/messages.json',
   'css/app.css',
@@ -239,7 +240,7 @@ def main():
   out_dir = os.path.join(BUILD_DIR, dir_name)
   archive_path = out_dir + '.zip'
   delete(out_dir, archive_path)
-  copy_files(SOURCE_DIR, out_dir, FILES)
+  copy_files(SOURCE_DIR, out_dir, FILES_TO_COPY)
 
   background_js_files = process_manifest(out_dir, version)
   compile_js(os.path.join(out_dir, 'js', 'background.js'),

--- a/index.html
+++ b/index.html
@@ -130,9 +130,10 @@
     </div>
   </div>
 
-  <!-- JS -->
-  <!-- Everything in this JS block will be replaced with a single .js include at compilation -->
   <script src="third_party/analytics/google-analytics-bundle.js" type="text/javascript"></script>
+  <script src="third_party/jquery/jquery-1.8.3.min.js" type="text/javascript"></script>
+  <!-- JS -->
+  <!-- Everything in this JS block will be replaced with a single .js file include at compilation -->
   <script src="third_party/CodeMirror/lib/codemirror.js" type="text/javascript"></script>
   <script src="third_party/CodeMirror/addon/edit/matchbrackets.js" type="text/javascript"></script>
   <script src="third_party/CodeMirror/addon/mode/simple.js" type="text/javascript"></script>
@@ -172,7 +173,6 @@
   <script src="third_party/CodeMirror/mode/xml/xml.js" type="text/javascript"></script>
   <script src="third_party/CodeMirror/mode/xquery/xquery.js" type="text/javascript"></script>
   <script src="third_party/CodeMirror/mode/yaml/yaml.js" type="text/javascript"></script>
-  <script src="third_party/jquery/jquery-1.8.3.min.js" type="text/javascript"></script>
   <script src="js/analytics.js" type="text/javascript"></script>
   <script src="js/app.js" type="text/javascript"></script>
   <script src="js/editor-cm.js" type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@
   </div>
 
   <!-- JS -->
+  <!-- Everything in this JS block will be replaced with a single .js include at compilation -->
   <script src="third_party/analytics/google-analytics-bundle.js" type="text/javascript"></script>
   <script src="third_party/CodeMirror/lib/codemirror.js" type="text/javascript"></script>
   <script src="third_party/CodeMirror/addon/edit/matchbrackets.js" type="text/javascript"></script>


### PR DESCRIPTION
A build script regression was introduced in #373 when some script tags were moved underneath a html comment <!-- JS -->. Turns out this comment is meaningful in the build script and this caused extra third_party js files to be compiled into our code unit (redundant code in build target but also triggered new warnings which triggered a build crash fixed in #376).

This patch
- Moves the third_party includes that were moved underneath this comment back out (retaining order from #373)
- Adds comments and more meaningful variable names so that the way the build script compiles JS code is more obvious

In future it might be a good idea to standardise whether third_party libraries are included into compilation unit.