### PR TITLE
Add check for null tab in showTab

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -241,6 +241,10 @@ Tabs.prototype.nextTab = function() {
 
 Tabs.prototype.showTab = function(tabId) {
   var tab = this.getTabById(tabId)
+  if (!tab) {
+    console.error('Can\'t find tab', tabId);
+    return;
+  }
   this.editor_.setSession(tab.getSession());
   this.currentTab_ = tab;
   $.event.trigger('switchtab', tab);


### PR DESCRIPTION
Null tabs after deleting and restoring files seemed to be causing an error where reloading the app did not reopen the previous files when it should have, but closing and opening the app opened the files.