### PR TITLE
Handle trying to open deleted files gracefully.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -58,8 +58,9 @@ TextApp.prototype.openTabs = function(entries) {
     this.tabs_.openFileEntry(entries[i]);
   }
   this.windowController_.focus_();
-  if (!this.tabs_.hasOpenTab())
+  if (!this.tabs_.hasOpenTab()) {
     this.tabs_.newTab();
+  }
 };
 
 TextApp.prototype.setHasChromeFrame = function(hasFrame) {

--- a/js/app.js
+++ b/js/app.js
@@ -49,19 +49,17 @@ TextApp.prototype.init = function() {
 };
 
 /**
- * @param {Array.<FileEntry>} entries The file entries to be opened.
- *
- * Open one tab per file. Usually called from the background page.
+ * Open one tab per FileEntry passed or a new Untitled tab if no tabs were
+ * successfully opened.
+ * @param {!Array.<FileEntry>} entries The file entries to be opened.
  */
-TextApp.prototype.openEntries = function(entries) {
+TextApp.prototype.openTabs = function(entries) {
   for (var i = 0; i < entries.length; i++) {
     this.tabs_.openFileEntry(entries[i]);
   }
   this.windowController_.focus_();
-};
-
-TextApp.prototype.openNew = function() {
-  this.tabs_.newTab();
+  if (!this.tabs_.hasOpenTab())
+    this.tabs_.newTab();
 };
 
 TextApp.prototype.setHasChromeFrame = function(hasFrame) {

--- a/js/background.js
+++ b/js/background.js
@@ -54,7 +54,8 @@ Background.prototype.launch = function(launchData) {
     var retainedEntryIds = data['retainedEntryIds'] || [];
     for (var i = 0; i < retainedEntryIds.length; i++) {
       chrome.fileSystem.restoreEntry(retainedEntryIds[i], function(entry) {
-        this.entriesToOpen_.push(entry);
+        if (!chrome.runtime.lastError)
+          this.entriesToOpen_.push(entry);
       }.bind(this));
     }
   }.bind(this));
@@ -73,8 +74,8 @@ Background.prototype.launch = function(launchData) {
         entries[i],
         function(entry) {
           if (this.windows_.length > 0) {
-            this.windows_[0].openEntries([entry]);
-          } else {
+            this.windows_[0].openTabs([entry]);
+          } else if (!chrome.runtime.lastError) {
             this.entriesToOpen_.push(entry);
           }
         }.bind(this));
@@ -123,13 +124,8 @@ Background.prototype.retainFiles_ = function(toRetain) {
 Background.prototype.onWindowReady = function(textApp) {
   this.windows_.push(textApp);
   textApp.setHasChromeFrame(this.ifShowFrame_());
-
-  if (this.entriesToOpen_.length > 0) {
-    textApp.openEntries(this.entriesToOpen_);
-    this.entriesToOpen_ = [];
-  } else {
-    textApp.openNew();
-  }
+  textApp.openTabs(this.entriesToOpen_);
+  this.entriesToOpen_ = [];
 };
 
 /**

--- a/js/background.js
+++ b/js/background.js
@@ -54,8 +54,9 @@ Background.prototype.launch = function(launchData) {
     var retainedEntryIds = data['retainedEntryIds'] || [];
     for (var i = 0; i < retainedEntryIds.length; i++) {
       chrome.fileSystem.restoreEntry(retainedEntryIds[i], function(entry) {
-        if (!chrome.runtime.lastError)
+        if (!chrome.runtime.lastError) {
           this.entriesToOpen_.push(entry);
+        }
       }.bind(this));
     }
   }.bind(this));

--- a/js/background_externs.js
+++ b/js/background_externs.js
@@ -24,8 +24,7 @@ TextApp.prototype.setHasChromeFrame = function(v) {};
 /**
  * @param {Array.<FileEntry>} entries
  */
-TextApp.prototype.openEntries = function(entries) {};
-TextApp.prototype.openNew = function() {};
+TextApp.prototype.openTabs = function(entries) {};
 /**
  * @return {Array.<FileEntry>}
  */

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -488,5 +488,5 @@ Tabs.prototype.onDocChanged_ = function(e, session) {
  * @return {boolean} True if at least one tab is open.
  */
 Tabs.prototype.hasOpenTab = function() {
-  return Boolean(this.tabs_.length);
+  return !!this.tabs_.length;
 };

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -24,6 +24,7 @@ Tab.prototype.getName = function() {
   if (this.entry_) {
     return this.entry_.name;
   } else {
+    // TODO: i18n 'Untitled' text
     return 'Untitled ' + this.id_;
   }
 };
@@ -480,4 +481,12 @@ Tabs.prototype.onDocChanged_ = function(e, session) {
   }
 
   tab.changed();
+};
+
+/**
+ * Determines whether any tabs are open.
+ * @return {boolean} True if at least one tab is open.
+ */
+Tabs.prototype.hasOpenTab = function() {
+  return Boolean(this.tabs_.length);
 };


### PR DESCRIPTION
Fixes #236 

When the app is first opened it tries to open the set of files that were opened on the last close.
Previously behavior:
- if one of these files had been deleted it would throw a console error on the background page and not open the file. 
- if all of these files had been deleted it would show 'Error' and have no open tabs at all. This might be the source of previous bug reports that were not reproducible. 

New behavior:
- files are opened if they can be, no error thrown if file doens't exist anymore
- if no files were successfully opened a new Untitled tab is opened (same behavior as if there were no previous open files)