### PR TITLE
Center filenames vertically within tab elements.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -117,6 +117,7 @@ img {
   -webkit-box-orient: horizontal;
   -webkit-box-pack: justify;
   display: -webkit-flex;
+  align-items: center;
   cursor: pointer;
 }
 


### PR DESCRIPTION
This causes a slight layout change because the close file icon is 4px larger than the filename, so the filenames have been shifted down 2px when vertially centered. See image diff
![here](https://user-images.githubusercontent.com/6046079/46329506-08609c80-c651-11e8-8ccb-cac71c24d1d2.png)

Pulling this change out into separate patch so that replacing the close file icon with MD doesn't cause a layout change beyond the close icon itself.