### PR TITLE
Ensure click styling for Material Componenet icons work on touch screen.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -320,7 +320,7 @@ header {
   opacity: 0.54;
 }
 
-.mdc-icon-button:focus {
+.mdc-icon-button:focus, .mdc-icon-button:active {
   opacity: 0.87;
 }
 


### PR DESCRIPTION
This was an oversight in #374 