### PR TITLE
Warn user of unsaved progress on close shortcut.

### DIFF
--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -6,7 +6,7 @@ function WindowController(editor, settings, analytics, tabs) {
   this.settings_ = settings;
   this.analytics_ = analytics;
   this.tabs_ = tabs;
-  $('#window-close').click(this.close_.bind(this));
+  $('#window-close').click(this.close.bind(this));
   $('#window-minimize').click(this.minimize_.bind(this));
   $('#window-maximize').click(this.maximize_.bind(this));
   $('#toggle-sidebar').click(this.toggleSidebar_.bind(this));
@@ -56,7 +56,10 @@ WindowController.prototype.setTheme = function(theme) {
   $('body').attr('theme', theme);
 };
 
-WindowController.prototype.close_ = function() {
+/**
+ * Close app window after warning user of all unsaved progress if present.
+ */
+WindowController.prototype.close = function() {
   this.tabs_.promptAllUnsaved(window.close);
 };
 


### PR DESCRIPTION
Fixes #400. Previously a function close() was called on window controller that did not exist in our implementation (we did have a close_() with a trailing underscore). This called through to some library close function that did not include our code to warn the user of unsaved progress.

This patch renames the close_() function to close() so that the external call calls through to the correct version.