### PR TITLE
Fix regression - copy, cut, and paste not working.

### DIFF
--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -95,7 +95,7 @@ HotkeysController.prototype.onKeydown_ = function(e) {
         return false;
 
       default:
-        return false;
+        break;
     }
   } else if (e.altKey) {
     if (e.key === ' ') {


### PR DESCRIPTION
Fixes #406.

Caused by default case in the hotkey switch statement returning false (since this is a jquery event handler, returning false causes the keydown event to stop propagating and prevent default behaviour). 