### PR TITLE
Relayout all ripples when their parent element changes size.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -405,11 +405,6 @@ header.search-active .search-navigation-button {
   width: 30px;
 }
 
-header.search-active .search-navigation-button::before {
-  /* Workaround for issue https://github.com/material-components/material-components-web/issues/3984 */
-  left: 6px;
-}
-
 #title-filename {
   color: #777;
   display: flex;

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -23,7 +23,10 @@ function WindowController(editor, settings, analytics, tabs) {
 
   // Initialize Material UI components
   for (const element of document.querySelectorAll('.mdc-icon-button')) {
-    mdc.ripple.MDCRipple.attachTo(element).unbounded = true;
+    const ripple = mdc.ripple.MDCRipple.attachTo(element);
+    ripple.unbounded = true;
+    // Required due to issue https://github.com/material-components/material-components-web/issues/3984
+    new ResizeObserver(() => { ripple.layout(); }).observe(element);
   }
 
   if (this.settings_.isReady()) {


### PR DESCRIPTION
Instead of hard coding 'left' property value as a workaround to issue https://github.com/material-components/material-components-web/issues/3984#issuecomment-433553956 as suggested on issue.

This is a more robust solution.