### PR TITLE
Replace minimize icon with Material Component remove icon.

### DIFF
--- a/build.py
+++ b/build.py
@@ -42,7 +42,6 @@ FILES_TO_COPY = [
   'images/check_no_box.png',
   'images/check_no_box_white.png',
   'images/menu.svg',
-  'images/minimize.svg',
   'third_party/analytics/google-analytics-bundle.js',
   'third_party/CodeMirror/lib/codemirror.css',
   'third_party/jquery/jquery-1.8.3.min.js',

--- a/css/app.css
+++ b/css/app.css
@@ -421,12 +421,13 @@ header.search-active .search-navigation-button {
   content: " *";
 }
 
-header.hide-controls #window-minimize {
-  visibility: hidden;
+#window-minimize {
+  /* Move the 'remove' icon down so it looks like a minimize icon */
+  padding-top: 18px;
 }
 
-#window-minimize {
-  background-image: url('../images/minimize.svg');
+header.hide-controls #window-minimize {
+  visibility: hidden;
 }
 
 header.hide-controls #window-maximize {

--- a/images/minimize.svg
+++ b/images/minimize.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="21px" height="21px" viewBox="0 0 21 21" enable-background="new 0 0 21 21" xml:space="preserve">
-  <rect y="14" x ="4" width="12" height="2"/>
-</svg>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,10 @@
               i18n-values="title:searchNextButton">expand_more</button>
         </div>
         <div id="title-filename" i18n-content="errorTitle"></div>
-        <div class="icon-button" id="window-minimize" i18n-values="title:minimizeButton"></div>
+        <button
+            class="mdc-icon-button material-icons"
+            id="window-minimize"
+            i18n-values="title:minimizeButton">remove</button>
         <button
             class="mdc-icon-button material-icons"
             id="window-maximize"


### PR DESCRIPTION
The minimize icon hasn't been implemented yet in the the Material Design icon library. I have instead used the remove icon and shifted it down with CSS so that it lines up with the bottom of the other icons.