### PR TITLE
For Issue #395: Long file names covered by search input

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -412,6 +412,7 @@ header.search-active .search-navigation-button {
   font-size: 15px;
   justify-content: left;
   overflow: hidden;
+  padding-left: 10px;
   text-overflow: ellipsis;
   -webkit-transition: all 200ms ease-in-out;
   white-space: nowrap;

--- a/css/app.css
+++ b/css/app.css
@@ -410,7 +410,7 @@ header.search-active .search-navigation-button {
   display: flex;
   flex: 1;
   font-size: 15px;
-  justify-content: center;
+  justify-content: left;
   overflow: hidden;
   text-overflow: ellipsis;
   -webkit-transition: all 200ms ease-in-out;


### PR DESCRIPTION
Aside: I'm new, so I don't know why I'm not seeing the ellipses when I open the app in dev mode ("Text Dev") from chrome://apps/
I noticed that there were other differences between opening the app normally vs. what I'm calling dev mode, even before I made edits.