### PR TITLE
Fix regression - white strip on edge of tab when dragging.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,3 +1,7 @@
+:root {
+  --tab-height: 42px;
+}
+
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, "Open Sans", sans-serif;
   font-size: 13px;
@@ -113,10 +117,10 @@ img {
 }
 
 #tabs-list li {
+  align-items: center;
   display: flex;
   flex-direction: row;
-  align-items: center;
-  height: 42px;
+  height: var(--tab-height, 42px);
   padding: 0 0 0 20px;
 }
 
@@ -137,10 +141,12 @@ img {
 }
 
 #tabs-list li .close {
-  height: 100%;
-  width: auto;
+  display: flex;
   font-size: 20px;
+  height: 100%;
+  justify-content: center;
   visibility: hidden;
+  width: var(--tab-height, 42px);
 }
 
 #tabs-list li:hover .close {

--- a/css/app.css
+++ b/css/app.css
@@ -120,7 +120,7 @@ img {
   align-items: center;
   display: flex;
   flex-direction: row;
-  height: var(--tab-height, 42px);
+  height: var(--tab-height);
   padding: 0 0 0 20px;
 }
 
@@ -146,7 +146,7 @@ img {
   height: 100%;
   justify-content: center;
   visibility: hidden;
-  width: var(--tab-height, 42px);
+  width: var(--tab-height);
 }
 
 #tabs-list li:hover .close {


### PR DESCRIPTION
This was caused by the new close file icon's width exceeding the height (I thought auto made them the same but it didn't) and the icon overlapping with the CodeMirror line number area. For some reason when the tab is dragged it also seems to drag this part of the overlap.

Before:

![screenshot from 2018-11-20 10-30-03](https://user-images.githubusercontent.com/6046079/48741470-5f790a00-ecaf-11e8-8d23-e26c65faefaf.png)

After:

![screenshot from 2018-11-20 10-30-15](https://user-images.githubusercontent.com/6046079/48741472-630c9100-ecaf-11e8-8736-ff269125e196.png)
