### PR TITLE
Fix regression - attempt to focus tab that is closed.

### DIFF
--- a/js/controllers/menu.js
+++ b/js/controllers/menu.js
@@ -51,7 +51,7 @@ MenuController.prototype.addNewTab_ = function(e, tab) {
   tabElement.addEventListener(
       'click', () => { this.tabButtonClicked_(id); });
   closeElement.addEventListener(
-      'click', () => { this.closeTabClicked_(id); });
+      'click', (event) => { this.closeTab_(event, id); });
 };
 
 MenuController.prototype.onDragStart_ = function(listItem) {
@@ -132,6 +132,12 @@ MenuController.prototype.tabButtonClicked_ = function(id) {
   return false;
 };
 
-MenuController.prototype.closeTabClicked_ = function(id) {
+/**
+ * Closes a file tab, removing it from the UI.
+ * @param {!Event} The triggering click event.
+ * @param {number} The id of the tab to close.
+ */
+MenuController.prototype.closeTab_ = function(e, id) {
   this.tabs_.close(id);
+  e.stopPropagation();
 };


### PR DESCRIPTION
This was caused in #381 when event handling was changed from jquery to es6. The es6 version bubbles the event to the tabElement, causing the tabButtonClicked_ handler to attempt to focus the tab after it has been closed. The result of this was a console error.