### PR TITLE
Delete redundant AppWindow externs.

### DIFF
--- a/js/background_externs.js
+++ b/js/background_externs.js
@@ -1,21 +1,6 @@
 /**
  * @constructor
  */
-function AppWindow() {}
-
-AppWindow.prototype.onClosed = {};
-/**
- * @param {function} callback
- */
-AppWindow.prototype.onClosed.addListener = function(callback) {};
-/**
- * @type {Window}
- */
-AppWindow.prototype.contentWindow = {};
-
-/**
- * @constructor
- */
 function TextApp() {}
 /**
  * @param {boolean} v


### PR DESCRIPTION
Deletes externs that are already included via https://raw.githubusercontent.com/google/closure-compiler/contrib/externs/chrome_extensions.js (linked in buld script).

This fixes 2 build warnings (diff of build warnings [here](https://gist.github.com/BugsNash/e8045549fce5960f3513911122d2bb1c/revisions)).