### PR TITLE
Line up header with text heading using css var instead of pixel pushing.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,4 +1,5 @@
 :root {
+  --header-height: 48px;
   --tab-height: 42px;
 }
 
@@ -52,21 +53,23 @@ img {
 }
 
 #sidebar h1 {
-  background-repeat: no-repeat;
   -webkit-app-region: drag;
-  cursor: default;
+  display: flex;
+  flex-direction: column;
   font-size: 21px;
   font-weight: normal;
-  margin-bottom: 4px;
-  margin-top: 12px;
+  height: var(--header-height);
+  justify-content: center;
+  margin: 0;
   padding: 0 20px;
   -webkit-user-select: none;
 }
 
 #sidebar hr {
-  height: 1px;
-  border: none;
   background-color: rgba(0,0,0,0.16);
+  border: none;
+  height: 1px;
+  margin: 0;
 }
 
 #sidebar ul {
@@ -211,7 +214,7 @@ img {
 }
 
 .settings-switch-ul {
-  margin: 4px 0 10px 0;
+  margin: 10px 0;
 }
 
 #settings-list input[type="text"] {
@@ -301,7 +304,7 @@ header {
   -webkit-app-region: drag;
   border-bottom: 1px solid #888;
   display: flex;
-  height: 48px;
+  height: var(--header-height);
   padding-left: 10px;
   position: relative;
   -webkit-user-select: none;


### PR DESCRIPTION
Also removes unused css rules and alphabetises.

This results in some minor movements in the file menu and open tabs menu items as the hr elements take up less space. There is plenty of padding on the menus themselves anyway and I have ensured that elements are still centered.

Before change:

![screenshot from 2018-11-22 15-58-01](https://user-images.githubusercontent.com/6046079/48882647-77978780-ee6f-11e8-840d-d858a3ce20ae.png)

After change:

![screenshot from 2018-11-22 15-58-25](https://user-images.githubusercontent.com/6046079/48882655-7c5c3b80-ee6f-11e8-9dd2-3179859d7470.png)



