### PR TITLE
Change style of dividers to match mocks.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,5 +1,7 @@
 :root {
+  --dark-divider-color: rgb(255, 255, 255, 0.12);
   --header-height: 48px;
+  --light-divider-color: #eee;
   --tab-height: 42px;
 }
 
@@ -31,7 +33,7 @@ img {
 }
 
 #sidebar {
-  border-right: 2px solid #eee;
+  border-right: 2px solid var(--light-divider-color);
   -webkit-box-orient: horizontal;
   -webkit-box-pack: start;
   color: #EBEBEB;
@@ -67,7 +69,7 @@ img {
 }
 
 #sidebar hr {
-  background-color: rgb(255, 255, 255, 0.12);
+  background-color: var(--dark-divider-color);
   border: none;
   height: 2px;
   margin: 0;
@@ -303,7 +305,7 @@ img {
 header {
   align-items: center;
   -webkit-app-region: drag;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--light-divider-color);
   display: flex;
   height: var(--header-height);
   padding-left: 10px;

--- a/css/app.css
+++ b/css/app.css
@@ -66,7 +66,7 @@ img {
 }
 
 #sidebar hr {
-  background-color: rgba(0,0,0,0.16);
+  background-color: rgb(255, 255, 255, 0.12);
   border: none;
   height: 1px;
   margin: 0;
@@ -302,7 +302,7 @@ img {
 header {
   align-items: center;
   -webkit-app-region: drag;
-  border-bottom: 1px solid #888;
+  border-bottom: 1px solid #eee;
   display: flex;
   height: var(--header-height);
   padding-left: 10px;

--- a/css/app.css
+++ b/css/app.css
@@ -68,7 +68,7 @@ img {
 #sidebar hr {
   background-color: rgb(255, 255, 255, 0.12);
   border: none;
-  height: 1px;
+  height: 2px;
   margin: 0;
 }
 
@@ -302,7 +302,7 @@ img {
 header {
   align-items: center;
   -webkit-app-region: drag;
-  border-bottom: 1px solid #eee;
+  border-bottom: 2px solid #eee;
   display: flex;
   height: var(--header-height);
   padding-left: 10px;

--- a/css/app.css
+++ b/css/app.css
@@ -31,6 +31,7 @@ img {
 }
 
 #sidebar {
+  border-right: 2px solid #eee;
   -webkit-box-orient: horizontal;
   -webkit-box-pack: start;
   color: #EBEBEB;

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -8,7 +8,7 @@ body[theme="dark"] .search-container {
 
 body[theme="dark"] #sidebar {
   background-color: #272822;
-  border-right-color: rgb(255, 255, 255, 0.12);
+  border-right-color: var(--dark-divider-color);
 }
 
 body[theme="dark"] #settings-menu {

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -8,6 +8,7 @@ body[theme="dark"] .search-container {
 
 body[theme="dark"] #sidebar {
   background-color: #272822;
+  border-right-color: rgb(255, 255, 255, 0.12);
 }
 
 body[theme="dark"] #settings-menu {

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -13,7 +13,7 @@ body[theme="light"] #settings-menu {
 }
 
 body[theme="light"] #sidebar hr {
-  background-color: #eee;
+  background-color: var(--light-divider-color);
 }
 
 body[theme="light"] #sidebar li:hover {

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -12,6 +12,10 @@ body[theme="light"] #settings-menu {
   color: #000;
 }
 
+body[theme="light"] #sidebar hr {
+  background-color: #eee;
+}
+
 body[theme="light"] #sidebar li:hover {
   background-color: #E5E5E5;
   border-left: 10px solid #C9C9C9;


### PR DESCRIPTION
When there is a dark element next to a light element I have used the lighter color for the divider (this was not specified in mocks but looks better to me).

Where possible I'm putting styling in the app.css over default-theme.css because the theme css takes a bit longer to load, resulting in a flash of unstyled UI on startup.

Default theme before:

![screenshot from 2018-12-03 13-58-11](https://user-images.githubusercontent.com/6046079/49350582-9c0f2180-f703-11e8-9bae-fa862c69db50.png)

Default theme after:

![screenshot from 2018-12-04 10-04-10](https://user-images.githubusercontent.com/6046079/49407262-09768d00-f7ac-11e8-9a11-4264343194a3.png)

Light theme before:

![screenshot from 2018-12-03 13-58-29](https://user-images.githubusercontent.com/6046079/49350584-9dd8e500-f703-11e8-963e-644891e5d746.png)

Light theme after:

![screenshot from 2018-12-04 10-04-24](https://user-images.githubusercontent.com/6046079/49407276-0ed3d780-f7ac-11e8-8f49-baca19f28789.png)

Dark theme before:

![screenshot from 2018-12-03 13-58-53](https://user-images.githubusercontent.com/6046079/49350585-9fa2a880-f703-11e8-89f3-4cb89c5a01f0.png)

Dark theme after:

![screenshot from 2018-12-04 10-04-38](https://user-images.githubusercontent.com/6046079/49407280-12fff500-f7ac-11e8-93c2-74180bed63ae.png)


