### PR TITLE
Change background-colours to match mocks.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,6 +1,8 @@
 :root {
+  --dark-background-color: #1f1f1f;
   --dark-divider-color: rgb(255, 255, 255, 0.12);
   --header-height: 48px;
+  --light-background-color: white;
   --light-divider-color: #eee;
   --tab-height: 42px;
 }
@@ -33,6 +35,7 @@ img {
 }
 
 #sidebar {
+  background-color: var(--dark-background-color);
   border-right: 2px solid var(--light-divider-color);
   color: #EBEBEB;
   cursor: default;
@@ -303,6 +306,7 @@ img {
 header {
   align-items: center;
   -webkit-app-region: drag;
+  background-color: var(--light-background-color);
   border-bottom: 2px solid var(--light-divider-color);
   display: flex;
   height: var(--header-height);
@@ -468,7 +472,7 @@ input[type=search]:focus {
 }
 
 .dialog-window {
-  background-color: #F5F5F5;
+  background-color: var(--light-background-color);
   border: 1px solid rgba(0,0,0,0.15);
   box-shadow: rgba(0,0,0,0.13) 0px 4px 30px;
   max-width: 50%;
@@ -516,6 +520,10 @@ input[type=search]:focus {
   bottom: 0;
   left: 0;
   right: 0;
+}
+
+.CodeMirror-gutters {
+  background-color: var(--light-background-color);
 }
 
 .CodeMirror-lines {

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -1,18 +1,9 @@
-body[theme="dark"] header {
-  background-color: #DDD;
-}
-
 body[theme="dark"] .search-container {
   border-color: #C1C1C1;
 }
 
 body[theme="dark"] #sidebar {
-  background-color: #272822;
   border-right-color: var(--dark-divider-color);
-}
-
-body[theme="dark"] #settings-menu {
-  background-color: #272822;
 }
 
 body[theme="dark"] #sidebar li:hover {
@@ -30,17 +21,21 @@ body[theme="dark"] #settings-list select {
   color: #EBEBEB;
 }
 
-body[theme="dark"] #settings-list select option {
-  background-color: #272822;
-}
-
 
 /* Based on CodeMirror dark theme */
 /* Based on Sublime Text's dark theme */
 
-.cm-s-dark.CodeMirror {background: #272822; color: #f8f8f2;}
+.cm-s-dark.CodeMirror {
+  background: var(--dark-background-color);
+  color: #f8f8f2;
+}
+
+.cm-s-dark .CodeMirror-gutters {
+  background: var(--dark-background-color);
+  border-right: 0px;
+}
+
 .cm-s-dark div.CodeMirror-selected {background: #49483E !important;}
-.cm-s-dark .CodeMirror-gutters {background: #272822; border-right: 0px;}
 .cm-s-dark .CodeMirror-linenumber {color: #d0d0d0;}
 .cm-s-dark .CodeMirror-cursor {border-left: 1px solid #f8f8f0 !important;}
 

--- a/css/theme-default.css
+++ b/css/theme-default.css
@@ -1,15 +1,3 @@
-body[theme="default"] header {
-  background-color: #F5F5F5;
-}
-
-body[theme="default"] #sidebar {
-  background-color: #333;
-}
-
-body[theme="default"] #settings-menu {
-  background-color: #333;
-}
-
 body[theme="default"] #sidebar li:hover {
   background-color: #3A3A3A;
   border-left: 10px solid #868686;
@@ -24,11 +12,6 @@ body[theme="default"] #settings-list input[type="text"] {
 body[theme="default"] #settings-list select {
   color: #EBEBEB;
 }
-
-body[theme="default"] #settings-list select option {
-  background-color: #333;
-}
-
 
 body[theme="default"] div.CodeMirror span.CodeMirror-matchingbracket {
   color: inherit !important;

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -1,14 +1,9 @@
-body[theme="light"] header {
-  background-color: #F5F5F5;
-}
-
 body[theme="light"] #sidebar {
-  background-color: #F5F5F5;
+  background-color: var(--light-background-color);
   color: #000;
 }
 
 body[theme="light"] #settings-menu {
-  background-color: #F5F5F5;
   color: #000;
 }
 


### PR DESCRIPTION
Also gets rid of redundant css and makes the theme dropdown background match the other input backgrounds in all themes to remove inconsistency.

Default theme before:

![screenshot from 2018-12-05 10-41-30](https://user-images.githubusercontent.com/6046079/49480396-a6076080-f87a-11e8-8143-4c9a3d8095ef.png)

Default theme after:

![screenshot from 2018-12-05 10-42-15](https://user-images.githubusercontent.com/6046079/49480406-ac95d800-f87a-11e8-8209-c2f9340a23f7.png)

Light theme before:

![screenshot from 2018-12-05 10-42-31](https://user-images.githubusercontent.com/6046079/49480414-b28bb900-f87a-11e8-8e5d-d1f1013facd6.png)

Light theme after:

![screenshot from 2018-12-05 10-42-44](https://user-images.githubusercontent.com/6046079/49480418-b91a3080-f87a-11e8-97a9-a6947d5c7d42.png)

Dark theme before:

![screenshot from 2018-12-05 10-43-00](https://user-images.githubusercontent.com/6046079/49480422-be777b00-f87a-11e8-88cd-4ed1570aadbc.png)

Dark theme after:

![screenshot from 2018-12-05 10-43-21](https://user-images.githubusercontent.com/6046079/49480427-c33c2f00-f87a-11e8-8fe4-4d8a8bf9caa9.png)

