### PR TITLE
Change active tab styling to match mocks.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -85,12 +85,18 @@ img {
 }
 
 #sidebar li {
-  cursor: pointer;
+  border-radius: 100px;
   -webkit-box-sizing: border-box;
+  cursor: pointer;
   margin: 0px;
   padding: 10px 0px 10px 20px;
   -webkit-user-select: none;
   white-space: nowrap;
+}
+
+#sidebar li:hover, #tabs-list li.active:hover {
+  background-color: #3a3a3a;
+  color: #fff;
 }
 
 #sidebar ::-webkit-scrollbar {
@@ -133,8 +139,7 @@ img {
 }
 
 #tabs-list li.active {
-  border-left: 10px solid #D1D1D1 !important;
-  padding-left: 10px;
+  background-color: rgb(95, 99, 104);
 }
 
 #tabs-list li .filename {
@@ -201,10 +206,6 @@ img {
   width: 100%;
   word-break: break-all;
   word-wrap: break-word;
-}
-
-#settings-list li:hover {
-  background-color: inherit;
 }
 
 #settings-list label {

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -6,13 +6,6 @@ body[theme="dark"] #sidebar {
   border-right-color: var(--dark-divider-color);
 }
 
-body[theme="dark"] #sidebar li:hover {
-  background-color: #3A3A3A;
-  border-left: 10px solid #868686;
-  color: #FFF;
-  padding-left: 10px;
-}
-
 body[theme="dark"] #settings-list input[type="text"] {
   color: #EBEBEB;
 }

--- a/css/theme-default.css
+++ b/css/theme-default.css
@@ -1,10 +1,3 @@
-body[theme="default"] #sidebar li:hover {
-  background-color: #3A3A3A;
-  border-left: 10px solid #868686;
-  color: #FFF;
-  padding-left: 10px;
-}
-
 body[theme="default"] #settings-list input[type="text"] {
   color: #EBEBEB;
 }

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -11,11 +11,10 @@ body[theme="light"] #sidebar hr {
   background-color: var(--light-divider-color);
 }
 
-body[theme="light"] #sidebar li:hover {
+body[theme="light"] #sidebar li:hover,
+body[theme="light"] #tabs-list li.active:hover {
   background-color: #E5E5E5;
-  border-left: 10px solid #C9C9C9;
   color: #000;
-  padding-left: 10px;
 }
 
 body[theme="light"] #settings-list input[type="text"] {
@@ -52,7 +51,7 @@ body[theme="light"] #settings-list input[type="checkbox"]:checked::after {
 }
 
 body[theme="light"] #tabs-list li.active {
-  border-left: 10px solid #9B9B9B !important;
+  background-color: rgb(248, 249, 250);
 }
 
 body[theme="light"] #sidebar .mdc-icon-button {


### PR DESCRIPTION
Adds background colour highlight for active tab.

Some styling changes also apply to all other list items in sidebar:
- remove left border on hover/active
- round corners of highlights

Makes hover styling take precedence over active tab styling and resolves inconsistency with this between themes (this involved moving default hover styling from themes specific css to main css).

Before/after pics show the file 'README.md' as the active (open) file and 'tabs.js' as being hovered on.
 
Default/dark theme before:

![screenshot from 2018-12-05 12-40-53](https://user-images.githubusercontent.com/6046079/49484609-c7bd1380-f88b-11e8-991e-c6b1dd80d9f1.png)

Default/dark theme after:

![screenshot from 2018-12-05 12-43-23](https://user-images.githubusercontent.com/6046079/49484686-0b178200-f88c-11e8-93ec-199ff0c60d1e.png)

Light theme before:

![screenshot from 2018-12-05 12-41-38](https://user-images.githubusercontent.com/6046079/49484663-f5a25800-f88b-11e8-99b6-55083406d2d1.png)

Light theme after:

![screenshot from 2018-12-05 12-41-11](https://user-images.githubusercontent.com/6046079/49484643-e28f8800-f88b-11e8-8c47-075787532734.png)

