### PR TITLE
Change light theme hover highlights to match mocks.

### DIFF
--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -11,9 +11,8 @@ body[theme="light"] #sidebar hr {
   background-color: var(--light-divider-color);
 }
 
-body[theme="light"] #sidebar li:hover,
-body[theme="light"] #tabs-list li.active:hover {
-  background-color: #E5E5E5;
+body[theme="light"] #sidebar li:hover {
+  background-color: rgb(210, 227, 252);
   color: #000;
 }
 
@@ -42,6 +41,10 @@ body[theme="light"] #settings-list input[type="checkbox"]:checked::after {
 
 body[theme="light"] #tabs-list li.active {
   background-color: var(--light-highlight-color);
+}
+
+body[theme="light"] #sidebar #tabs-list li:hover {
+  background-color: rgb(232, 240, 254);
 }
 
 body[theme="light"] #sidebar .mdc-icon-button {


### PR DESCRIPTION
Dark theme blocked on feedback from designers.

Before:

![before1](https://user-images.githubusercontent.com/6046079/49708792-3253c200-fc85-11e8-8815-79310bd0cf28.png)
![before2](https://user-images.githubusercontent.com/6046079/49708795-34b61c00-fc85-11e8-8e9c-b604ef2ce2b5.png)

After:

![after1](https://user-images.githubusercontent.com/6046079/49708786-2ec03b00-fc85-11e8-9aef-dc6dbcc1ba5f.png)
![after2](https://user-images.githubusercontent.com/6046079/49708789-3089fe80-fc85-11e8-9323-986ba1294108.png)


