### PR TITLE
Delete border on focussed text input in light theme.

### DIFF
--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -21,7 +21,6 @@ body[theme="light"] #sidebar input {
 }
 
 body[theme="light"] #settings-list input[type="text"]:focus {
-  border: 1px solid #242424;
   outline: none;
 }
 


### PR DESCRIPTION
This was an oversight in #435 