### PR TITLE
Make text inputs take on highlight color on hover and when active.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,11 +1,13 @@
 :root {
+  --dark-accent-color: #3a3a3a;
   --dark-background-color: #1f1f1f;
   --dark-divider-color: rgb(255, 255, 255, 0.12);
   --dark-highlight-color: rgb(95, 99, 104);
   --header-height: 48px;
+  --light-accent-color: rgb(248, 249, 250);
   --light-background-color: white;
   --light-divider-color: #eee;
-  --light-highlight-color: rgb(248, 249, 250);
+  --light-highlight-color: rgb(210, 227, 252);
   --tab-height: 36px;
 }
 
@@ -100,12 +102,12 @@ img {
 }
 
 #sidebar li:hover, #tabs-list li.active:hover {
-  background-color: #3a3a3a;
+  background-color: var(--dark-highlight-color);
   color: #fff;
 }
 
 #sidebar input {
-  background-color: var(--dark-highlight-color);
+  background-color: var(--dark-accent-color);
 }
 
 #sidebar ::-webkit-scrollbar {
@@ -146,7 +148,7 @@ img {
 }
 
 #tabs-list li.active {
-  background-color: var(--dark-highlight-color);
+  background-color: var(--dark-accent-color);
 }
 
 #tabs-list li .filename {
@@ -236,12 +238,18 @@ img {
   border-radius: 100px;
   font-size: 14px;
   height: 100%;
+  padding: 0;
   text-align: center;
   -webkit-user-select: auto;
   width: 55px;
 }
 
+#settings-list li:hover input[type="text"] {
+  background-color: inherit;
+}
+
 #settings-list input[type="text"]:focus {
+  background-color: var(--dark-highlight-color);
   outline: none;
 }
 
@@ -278,7 +286,7 @@ img {
 #settings-list select {
   -webkit-app-region: no-drag;
   -webkit-appearance: none;
-  background: url('../images/menu.svg') no-repeat 70px / 18px var(--dark-highlight-color);
+  background: url('../images/menu.svg') no-repeat 70px / 18px var(--dark-accent-color);
   border: 1px solid #888;
   border-radius: 1px;
   cursor: pointer;

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -12,21 +12,22 @@ body[theme="light"] #sidebar hr {
 }
 
 body[theme="light"] #sidebar li:hover {
-  background-color: rgb(210, 227, 252);
+  background-color: var(--light-highlight-color);
   color: #000;
 }
 
 body[theme="light"] #sidebar input {
-  background-color: var(--light-highlight-color);
+  background-color: var(--light-accent-color);
 }
 
 body[theme="light"] #settings-list input[type="text"]:focus {
+  background-color: var(--light-highlight-color);
   outline: none;
 }
 
 body[theme="light"] #settings-list select {
   -webkit-appearance: none;
-  background: url('../images/menu.svg') no-repeat 70px / 18px var(--light-highlight-color);
+  background: url('../images/menu.svg') no-repeat 70px / 18px var(--light-accent-color);
 }
 
 body[theme="light"] #settings-list select:focus {
@@ -39,7 +40,7 @@ body[theme="light"] #settings-list input[type="checkbox"]:checked::after {
 }
 
 body[theme="light"] #tabs-list li.active {
-  background-color: var(--light-highlight-color);
+  background-color: var(--light-accent-color);
 }
 
 body[theme="light"] #sidebar #tabs-list li:hover {


### PR DESCRIPTION
- changes meaning of *-highlight-color vars to mean the background color on hover
- adds *-accent-color vars to mean the background color of the active tab and text inputs
- swaps the dark theme highlight and accent colors so that the highlight is the lighter (more prominant) color and the accent is the darker (less prominant color). this is consistent with the light theme. the mocks are currently unclear on how to handle the dark theme colors here and have changed recently. if/when designers clarify on the highlight/accent color in the dark theme this can easily be updated with the vars
- makes the text inputs take on the highlight color when their list item is hovered on and when they are active (selected).


Dark theme accent/highlight before

![screenshot from 2018-12-14 10-04-22](https://user-images.githubusercontent.com/6046079/49973169-2c612800-ff88-11e8-8993-5d1d4fa48e99.png)

Dark theme accent/highlight after

![screenshot from 2018-12-14 10-04-08](https://user-images.githubusercontent.com/6046079/49973165-29663780-ff88-11e8-8b68-d6c6020a8177.png)

Input on hover before

![screenshot from 2018-12-14 10-04-35](https://user-images.githubusercontent.com/6046079/49973181-37b45380-ff88-11e8-81dc-cccd85e63c3b.png)

Input on hover after

![screenshot from 2018-12-14 10-04-49](https://user-images.githubusercontent.com/6046079/49973189-3f73f800-ff88-11e8-8600-1ba0ddf7a07c.png)

Active input before

![screenshot from 2018-12-14 10-10-10](https://user-images.githubusercontent.com/6046079/49973251-7f3adf80-ff88-11e8-80a6-7f365357ac31.png)

Active input after

![screenshot from 2018-12-14 10-05-16](https://user-images.githubusercontent.com/6046079/49973209-5286c800-ff88-11e8-856e-9601b09e8f95.png)