### PR TITLE
Tweak layout of sidebar list items.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -8,6 +8,7 @@
   --light-background-color: white;
   --light-divider-color: #eee;
   --light-highlight-color: rgb(210, 227, 252);
+  --settings-input-width: 55px;
   --tab-height: 36px;
 }
 
@@ -227,6 +228,7 @@ img {
   display: flex;
   flex: 1;
   height: 100%;
+  max-width: calc(100% - var(--settings-input-width));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -245,7 +247,7 @@ img {
   padding: 0;
   text-align: center;
   -webkit-user-select: auto;
-  width: 55px;
+  width: var(--settings-input-width);
 }
 
 #settings-list li:hover input[type="text"] {
@@ -264,9 +266,8 @@ img {
   -webkit-box-sizing: border-box;
   cursor: pointer;
   height: 18px;
-  /* TODO(https://github.com/GoogleChromeLabs/text-app/issues/345):
-       remove pixel pushing once checkboxes are replaced with switches */
-  margin-right: 18px;
+  margin-left: auto;
+  margin-right: auto;
   position: relative;
   width: 18px;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -95,8 +95,8 @@ img {
   display: flex;
   cursor: pointer;
   height: var(--tab-height);
-  margin: 4px 0;
-  padding-left: 20px;
+  margin: 4px 8px;
+  padding: 0 16px;
   -webkit-user-select: none;
   white-space: nowrap;
 }
@@ -163,17 +163,24 @@ img {
 }
 
 #tabs-list li .close {
-  display: flex;
+  display: none;
   font-size: 20px;
   height: 100%;
   justify-content: center;
   padding: 0;
-  visibility: hidden;
   width: var(--tab-height);
 }
 
+#tabs-list li:hover {
+  padding-right: 0;
+}
+
+#tabs-list li:hover .filename {
+  max-width: calc(100% - var(--tab-height));
+}
+
 #tabs-list li:hover .close {
-  visibility: visible;
+  display: flex;
 }
 
 #file-tabs-menu {
@@ -212,17 +219,17 @@ img {
   -webkit-box-orient: horizontal;
   -webkit-box-align: end;
   display: -webkit-flex;
-  padding-right: 20px;
-  width: 100%;
+  padding-right: 0;
   word-break: break-all;
   word-wrap: break-word;
 }
 
 #settings-list label {
-  -webkit-flex: 1 1 auto;
+  align-items: center;
   cursor: pointer;
-  display: inline;
-  min-width: 0;
+  display: flex;
+  flex: 1;
+  height: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -260,7 +267,7 @@ img {
   -webkit-box-sizing: border-box;
   cursor: pointer;
   height: 18px;
-  margin: -3px 0;
+  margin-right: 18px;
   position: relative;
   width: 18px;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -264,6 +264,8 @@ img {
   -webkit-box-sizing: border-box;
   cursor: pointer;
   height: 18px;
+  /* TODO(https://github.com/GoogleChromeLabs/text-app/issues/345):
+       remove pixel pushing once checkboxes are replaced with switches */
   margin-right: 18px;
   position: relative;
   width: 18px;

--- a/css/app.css
+++ b/css/app.css
@@ -167,16 +167,13 @@ img {
   font-size: 20px;
   height: 100%;
   justify-content: center;
+  min-width: var(--tab-height);
   padding: 0;
   width: var(--tab-height);
 }
 
 #tabs-list li:hover {
   padding-right: 0;
-}
-
-#tabs-list li:hover .filename {
-  max-width: calc(100% - var(--tab-height));
 }
 
 #tabs-list li:hover .close {


### PR DESCRIPTION
Changes:
- Makes text and background highlight layout on list items match mocks by changing padding/margins
- Makes clicking on any part of list item for settings input items select the input (previously as label wasn't 100% of height you needed to click exactly on the text).
- Centers checkboxes to text inputs (introduces temporary pixel pushing as these are about to be replaced with switches and more thought will be put into centering for that patch).
- Fixes close button on long file names - previously pushed off the end, now takes up space in list item and shortens file name


Text and background highlight before:

![screenshot from 2018-12-17 11-07-54](https://user-images.githubusercontent.com/6046079/50122829-6d23ae80-02b2-11e9-9a37-5b79ed16c9eb.png)

Text and background highlight after:

![screenshot from 2018-12-17 11-23-50](https://user-images.githubusercontent.com/6046079/50122836-7876da00-02b2-11e9-923f-0bbb8d85d3cc.png)

Settings checkboxes before:

![screenshot from 2018-12-17 11-10-26](https://user-images.githubusercontent.com/6046079/50122843-82004200-02b2-11e9-93ab-6c1dba952f76.png)

Settings checkboxes after:

![screenshot from 2018-12-17 11-10-47](https://user-images.githubusercontent.com/6046079/50122851-8a587d00-02b2-11e9-8ab0-91eeee3014d1.png)

Close with long file name before:

![screenshot from 2018-12-18 10-51-28](https://user-images.githubusercontent.com/6046079/50122968-f804a900-02b2-11e9-8c18-133b17efbca2.png)

Close with long file name after:

![screenshot from 2018-12-18 10-49-41](https://user-images.githubusercontent.com/6046079/50122959-f0dd9b00-02b2-11e9-9c2c-42c3149044ba.png)
