### PR TITLE
Disable mdc-icon-buttons when dialog is active.

### DIFF
--- a/js/controllers/dialog.js
+++ b/js/controllers/dialog.js
@@ -34,7 +34,7 @@ DialogController.prototype.show = function(callback) {
  */
 DialogController.prototype.disableEverything_ = function() {
   this.editor_.disable();
-  inputs = document.querySelectorAll(
+  const inputs = document.querySelectorAll(
       'input, select, textarea, .mdc-icon-button');
   for (var i = 0; i < inputs.length; i++) {
     this.disabledElements_.push({'element': inputs[i],

--- a/js/controllers/dialog.js
+++ b/js/controllers/dialog.js
@@ -31,6 +31,7 @@ DialogController.prototype.show = function(callback) {
 
 /**
  * Disables keyboard tabbing to all UI elements outside of the dialog box.
+ * @private
  */
 DialogController.prototype.disableEverything_ = function() {
   this.editor_.disable();
@@ -46,6 +47,7 @@ DialogController.prototype.disableEverything_ = function() {
 /**
  * Re-enables keyboard tabbing to all UI elements previously disabled due to the
  * dialog box.
+ * @private
  */
 DialogController.prototype.reenableEverything_ = function() {
   for (var i = 0; i < this.disabledElements_.length; i++) {

--- a/js/controllers/dialog.js
+++ b/js/controllers/dialog.js
@@ -31,7 +31,7 @@ DialogController.prototype.show = function(callback) {
 
 DialogController.prototype.disableEverything_ = function() {
   this.editor_.disable();
-  var inputs = $('input, select, textarea');
+  var inputs = $('input, select, textarea, .mdc-icon-button');
   for (var i = 0; i < inputs.length; i++) {
     this.disabledElements_.push({'element': inputs[i],
                                'index': inputs[i].tabIndex});

--- a/js/controllers/dialog.js
+++ b/js/controllers/dialog.js
@@ -29,9 +29,13 @@ DialogController.prototype.show = function(callback) {
   this.container_.find('.dialog-button').first().focus();
 };
 
+/**
+ * Disables keyboard tabbing to all UI elements outside of the dialog box.
+ */
 DialogController.prototype.disableEverything_ = function() {
   this.editor_.disable();
-  var inputs = $('input, select, textarea, .mdc-icon-button');
+  inputs = document.querySelectorAll(
+      'input, select, textarea, .mdc-icon-button');
   for (var i = 0; i < inputs.length; i++) {
     this.disabledElements_.push({'element': inputs[i],
                                'index': inputs[i].tabIndex});
@@ -39,6 +43,10 @@ DialogController.prototype.disableEverything_ = function() {
   }
 };
 
+/**
+ * Re-enables keyboard tabbing to all UI elements previously disabled due to the
+ * dialog box.
+ */
 DialogController.prototype.reenableEverything_ = function() {
   for (var i = 0; i < this.disabledElements_.length; i++) {
     this.disabledElements_[i]['element'].tabIndex =


### PR DESCRIPTION
Fixes a regression introduced when the icon buttons were replaced with Material Components. From a dialog box users were able to tab to the menu bar icons (menu, minimise, maximise and close) and activate them.