### PR TITLE
Adding transitions; Fixing dark mode header bar; Fixing sidebar border staying while menu is closed

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -55,7 +55,7 @@ img {
   height: 100%;
   overflow: hidden;
   position: relative;
-  -webkit-transition: width 0.2s ease-in-out;
+  -webkit-transition: width 0.2s ease-in-out, background-color 0.2s;
   width: 0;
 }
 

--- a/css/app.css
+++ b/css/app.css
@@ -114,6 +114,12 @@ img {
   cursor: pointer;
 }
 
+#sidebar li,
+#sidebar .mdc-form-field,
+#tabs-list li.active {
+  -webkit-transition: all 200ms;
+}
+
 #sidebar li:hover,
 #sidebar .mdc-form-field:hover,
 #tabs-list li.active:hover {

--- a/css/app.css
+++ b/css/app.css
@@ -118,12 +118,6 @@ img {
   cursor: pointer;
 }
 
-#sidebar li,
-#sidebar .mdc-form-field,
-#tabs-list li.active {
-  -webkit-transition: all 200ms;
-}
-
 #sidebar li:hover,
 #sidebar .mdc-form-field:hover,
 #tabs-list li.active:hover {

--- a/css/app.css
+++ b/css/app.css
@@ -128,6 +128,7 @@ img {
 }
 
 #sidebar input {
+  -webkit-transition: background-color 200ms;
   background-color: var(--dark-accent-color);
 }
 

--- a/css/app.css
+++ b/css/app.css
@@ -346,6 +346,7 @@ header {
 
 header .mdc-icon-button {
   opacity: 0.54;
+  -webkit-transition: opacity 200ms;
 }
 
 header .mdc-icon-button:focus, header .mdc-icon-button:active {
@@ -478,6 +479,10 @@ input[type=search]:focus {
 ::-webkit-search-results-button,
 ::-webkit-search-results-decoration {
   display: none;
+}
+
+.mdc-icon-button::before {
+  -webkit-transition: opacity 200ms;
 }
 
 /* Dialog */

--- a/css/app.css
+++ b/css/app.css
@@ -13,6 +13,10 @@
   --tab-height: 36px;
 }
 
+* {
+  -webkit-transition: background-color 200ms;
+}
+
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, "Open Sans", sans-serif;
   font-size: 13px;
@@ -128,7 +132,6 @@ img {
 }
 
 #sidebar input {
-  -webkit-transition: background-color 200ms;
   background-color: var(--dark-accent-color);
 }
 

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -74,3 +74,12 @@ body[theme="dark"] div.CodeMirror span.CodeMirror-matchingbracket {
 body[theme="dark"] div.CodeMirror span.CodeMirror-nonmatchingbracket {
   color: inherit !important;
 }
+
+body[theme="dark"] header.search-active .search-navigation-button {
+  border-color: var(--dark-divider-color);
+}
+
+body[theme="dark"] .mdc-icon-button::before,
+body[theme="dark"] .mdc-icon-button::after {
+  background-color: var(--light-background-color);
+}

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -1,5 +1,15 @@
 body[theme="dark"] .search-container {
   border-color: #C1C1C1;
+  background-color: var(--dark-background-color);
+}
+
+body[theme="dark"] #search-input,
+body[theme="dark"] .mdc-icon-button {
+  color: white;
+}
+
+body[theme="dark"] #search-counting.nomatches {
+  color: #ff0000;
 }
 
 body[theme="dark"] #sidebar {
@@ -23,7 +33,7 @@ body[theme="dark"] #settings-list input[type="text"] {
   border-right: 0px;
 }
 
-.cm-s-dark div.CodeMirror-selected {background: #49483E !important;}
+.cm-s-dark div.CodeMirror-selected, body[theme="dark"] header {background: #49483E !important;}
 .cm-s-dark .CodeMirror-linenumber {color: #d0d0d0;}
 .cm-s-dark .CodeMirror-cursor {border-left: 1px solid #f8f8f0 !important;}
 

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -1,10 +1,14 @@
 body[theme="dark"] header,
 body[theme="dark"] .search-container {
-  background-color: var(--dark-background-color)
+  background-color: var(--dark-background-color);
+}
+
+body[theme="dark"] header {
+  border-bottom: 2px solid var(--dark-divider-color);
 }
 
 body[theme="dark"] .search-container {
-  border-color: #C1C1C1;
+  border-color: var(--dark-divider-color);
 }
 
 body[theme="dark"] #search-input,

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -13,7 +13,7 @@ body[theme="dark"] .search-container {
 
 body[theme="dark"] #search-input,
 body[theme="dark"] .mdc-icon-button {
-  color: white;
+  color: #EBEBEB;
 }
 
 body[theme="dark"] #search-counting.nomatches {

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -1,6 +1,10 @@
+body[theme="dark"] header,
+body[theme="dark"] .search-container {
+  background-color: var(--dark-background-color)
+}
+
 body[theme="dark"] .search-container {
   border-color: #C1C1C1;
-  background-color: var(--dark-background-color);
 }
 
 body[theme="dark"] #search-input,
@@ -9,7 +13,7 @@ body[theme="dark"] .mdc-icon-button {
 }
 
 body[theme="dark"] #search-counting.nomatches {
-  color: #ff0000;
+  color: #B00;
 }
 
 body[theme="dark"] #sidebar {
@@ -33,7 +37,7 @@ body[theme="dark"] #settings-list input[type="text"] {
   border-right: 0px;
 }
 
-.cm-s-dark div.CodeMirror-selected, body[theme="dark"] header {background: #49483E !important;}
+.cm-s-dark div.CodeMirror-selected {background: #49483E !important;}
 .cm-s-dark .CodeMirror-linenumber {color: #d0d0d0;}
 .cm-s-dark .CodeMirror-cursor {border-left: 1px solid #f8f8f0 !important;}
 

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -50,6 +50,7 @@ WindowController.prototype.initUI_ = function() {
 }
 
 WindowController.prototype.initSidebar_ = function() {
+  // FIXME: move this to CSS where possible (init code)
   if (this.settings_.get('sidebaropen')) {
     $('#sidebar').css('width', this.settings_.get('sidebarwidth') + 'px');
     $('#sidebar').css('border-right-width', '2px');
@@ -108,6 +109,7 @@ WindowController.prototype.setAlwaysOnTop = function(isAlwaysOnTop) {
 };
 
 WindowController.prototype.toggleSidebar_ = function() {
+  // FIXME: Move this to css where possible (toggle code)
   if (this.settings_.get('sidebaropen')) {
     this.settings_.set('sidebaropen', false);
     $('#sidebar').css('width', '0');

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -40,14 +40,14 @@ WindowController.prototype.initUI_ = function() {
   }
   for (const element of document.querySelectorAll('.mdc-radio')) {
     const formField = new mdc.formField.MDCFormField(element.parentElement);
-    formField.input = new mdc.radio.MDCRadio(element);;
+    formField.input = new mdc.radio.MDCRadio(element);
   }
   if (this.settings_.isReady()) {
     this.initSidebar_();
   } else {
     $(document).bind('settingsready', this.initSidebar_.bind(this));
   }
-}
+};
 
 WindowController.prototype.initSidebar_ = function() {
   // FIXME: move this to CSS where possible (init code)

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -52,9 +52,11 @@ WindowController.prototype.initUI_ = function() {
 WindowController.prototype.initSidebar_ = function() {
   if (this.settings_.get('sidebaropen')) {
     $('#sidebar').css('width', this.settings_.get('sidebarwidth') + 'px');
+    $('#sidebar').css('border-right-width', '2px');
     $('#toggle-sidebar').attr('title', chrome.i18n.getMessage('closeSidebarButton'));
   } else {
     $('#sidebar').css('width', '0');
+    $('#sidebar').css('border-right-width', '0');
     $('#toggle-sidebar').attr('title', chrome.i18n.getMessage('openSidebarButton'));
   }
 };
@@ -109,10 +111,12 @@ WindowController.prototype.toggleSidebar_ = function() {
   if (this.settings_.get('sidebaropen')) {
     this.settings_.set('sidebaropen', false);
     $('#sidebar').css('width', '0');
+    $('#sidebar').css('border-right-width', '0');
     $('#toggle-sidebar').attr('title', chrome.i18n.getMessage('openSidebarButton'));
   } else {
     this.settings_.set('sidebaropen', true);
     $('#sidebar').css('width', this.settings_.get('sidebarwidth') + 'px');
+    $('#sidebar').css('border-right-width', '2px');
     $('#toggle-sidebar').attr('title', chrome.i18n.getMessage('closeSidebarButton'));
   }
   this.editor_.focus();


### PR DESCRIPTION
- Added transitions to sidebar list items (such as settings selectors).
- Added transitions to swap colors over when a theme is changed.
- Menu icon now animates the background shadow's opacity.
- Header bar now matches the rest of the dark theme.
- Sidebar border is no longer visible after closing menu. (Fixes #460)