### PR TITLE
Removed spellcheck on textarea

### DIFF
--- a/js/editor-ta.js
+++ b/js/editor-ta.js
@@ -87,6 +87,7 @@ EditorTextArea.prototype.attachTextArea = function(textarea) {
   }
 
   textarea.setAttribute('id', 'editor-textarea');
+  textarea.setAttribute('spellcheck', 'false');
   textarea.style.fontSize = initFontSize;
   textarea.addEventListener('input', this.onInput);
 


### PR DESCRIPTION
Removes spellcheck on the textarea in a11y mode. 

By default every textarea has spell check enabled and will underline words that aren't in the dictionary with a red underline. This is undesirable with a code editor which frequently involves words, syntax and grammar that would set the spellcheck off.