### PR TITLE
Removed most uses of getBoundingClientRect to improve performance

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -661,5 +661,4 @@ header.search-active ~ #editor div.CodeMirror .cm-matchhighlight {
   visibility: hidden;
   font-family: monospace;
   line-height: var(--editor-line-height);
-  word-wrap: break-word;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -538,6 +538,7 @@ header.hide-controls #window-close {
   line-height: var(--editor-line-height);
   font-size: 14px;
   overflow: hidden;
+  white-space: break-spaces;
 }
 
 #editor-textarea:focus, #editor-textarea:hover {

--- a/css/app.css
+++ b/css/app.css
@@ -14,6 +14,7 @@
    */
   --editor-gutter-horiztonal-padding: 8px;
   --editor-gutter-min-size: 29px;
+  /* 20px to give enough room at the bottom for a scrollbar */
   --editor-gutter-padding: 4px 3px 16px 5px;
   --editor-gutter-vertical-padding: 20px;
   --editor-line-height: 1.2em;
@@ -543,14 +544,12 @@ header.hide-controls #window-close {
   outline: none;
 }
 
-
 .editor-textarea-container.dark-theme .editor-textarea-wrapper {
   background: var(--dark-background-color);
   color: var(--dark-theme-text-color);
 }
 
-#ed
-itor-textarea:focus {
+#editor-textarea:focus {
   outline: none;
 }
 
@@ -655,18 +654,11 @@ header.search-active ~ #editor div.CodeMirror .cm-matchhighlight {
   background-color: rgba(253, 207, 76, .5);
 }
 
-.hidden-textarea-mirror {
-  position: absolute;
-  visibility: hidden;
-  font-family: monospace;
-  line-height: var(--editor-line-height);
-  white-space: nowrap;
-}
 
-.hidden-line-mirror {
+.hidden-character-sizer {
   position: absolute;
   visibility: hidden;
   font-family: monospace;
   line-height: var(--editor-line-height);
-  word-break: break-all;
+  word-wrap: break-word;
 }

--- a/js/editor-ta.js
+++ b/js/editor-ta.js
@@ -21,7 +21,7 @@ function EditorTextArea(editorElement, settings) {
   this.lineHeightCache = [];
   this.longestLine_ = 0;
   const initFontSize = this.settings_.get('fontsize') + 'px';
-  this.totalCalculatedHeight_ = this.settings_.get('fontsize');
+  this.totalCalculatedHeight_ = null;
   // We need a named reference to this arrow function so we can remove it
   // as an EventListener.
   this.onInput = () => {
@@ -324,7 +324,6 @@ EditorTextArea.prototype.getLineHeight = function(line) {
       wordLength = 0;
     }
   }
-  console.log('>>>>>', lines);
   return lines * charHeight;
 }
 


### PR DESCRIPTION
This was suggested in a previous PR by @BugsNash but avoided because the word wrap logic was deemed not worth the additional complexity. After a round of testing it was discovered that using getBoundngClientRect caused a significant speed hit which made a11y mode struggle to handle any files larger then 1000 lines.

As such manually calculating the dimensions of each line to preserve performance was now worth the additional complexity it added, this PR removes most uses of getBoundingClientRect and implements this.
