### PR TITLE
Screen reader mode

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -67,11 +67,11 @@
     "message": "Always on top",
     "description": "The label for the checkbox in settings tab that sets the window always on top."
   },
-  "screenreaderModeSetting": {
-    "message": "Screen Reader Mode",
+  "screenReaderModeSetting": {
+    "message": "Screen reader mode",
     "description": "The label for the checkbox in settings tab that activates screen reader mode, this mode allows for screenreaders to function correctly but disables syntax highlighting, tab control, line wrapping and smart indenting."
   },
-  "screenreaderModeHelp": {
+  "screenReaderModeHelp": {
     "message": "For a more optimised screen reader experience turn on screen reader mode from the settings menu.",
     "description": "The message that is read out to a user when they first open the text app with a screen reader, this message should notify users who are using a screen reader about the presence of the screen reader mode setting which optimises the app for use with a screen reader."
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -67,6 +67,14 @@
     "message": "Always on top",
     "description": "The label for the checkbox in settings tab that sets the window always on top."
   },
+  "screenreaderModeSetting": {
+    "message": "Screen Reader Mode",
+    "description": "The label for the checkbox in settings tab that activates screen reader mode, this mode allows for screenreaders to function correctly but disables syntax highlighting, tab control, line wrapping and smart indenting."
+  },
+  "screenreaderModeHelp": {
+    "message": "For a more optimised screen reader experience turn on screen reader mode from the settings menu.",
+    "description": "The message that is read out to a user when they first open the text app with a screen reader, this message should notify users who are using a screen reader about the presence of the screen reader mode setting which optimises the app for use with a screen reader."
+  },
   "defaultThemeOption": {
     "message": "Default",
     "description": "The text of the default Option Theme."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -67,14 +67,6 @@
     "message": "Always on top",
     "description": "The label for the checkbox in settings tab that sets the window always on top."
   },
-  "screenReaderModeSetting": {
-    "message": "Screen reader mode",
-    "description": "The label for the checkbox in settings tab that activates screen reader mode, this mode allows for screenreaders to function correctly but disables syntax highlighting, tab control, line wrapping and smart indenting."
-  },
-  "screenReaderModeHelp": {
-    "message": "For a more optimised screen reader experience turn on screen reader mode from the settings menu.",
-    "description": "The message that is read out to a user when they first open the text app with a screen reader, this message should notify users who are using a screen reader about the presence of the screen reader mode setting which optimises the app for use with a screen reader."
-  },
   "defaultThemeOption": {
     "message": "Default",
     "description": "The text of the default Option Theme."

--- a/css/app.css
+++ b/css/app.css
@@ -3,13 +3,14 @@
   --dark-background-color: #1f1f1f;
   --dark-divider-color: var(--dark-accent-color);
   --dark-highlight-color: rgb(26, 115, 232, 0.26);
+  --disabled-opacity: 0.38;
   /* These colors are copied from codemirror to maintain consistency. */
   --light-theme-line-number-color: #999999;
   --dark-theme-line-number-color: #d0d0d0;
   --light-theme-text-color: #000000;
   --dark-theme-text-color: #f8f8f2;
   /*
-   * editor styles are mostly copied from codemirror so that the text area
+   * Editor styles are mostly copied from codemirror so that the text area
    * maintains the same look.
    */
   --editor-line-height: 1.2em;
@@ -391,7 +392,7 @@ header .mdc-icon-button:focus, header .mdc-icon-button:active {
 }
 
 .search-container.disabled {
-  opacity: 0.38;
+  opacity: var(--disabled-opacity);
 }
 
 #search-input-container {
@@ -499,7 +500,7 @@ header.hide-controls #window-close {
   border: none;
 }
 input[type=text][disabled] {
-  opacity: .38;
+  opacity: var(--disabled-opacity);
 }
 /* Markup below overrides default search input box styling. */
 input[type=search] {

--- a/css/app.css
+++ b/css/app.css
@@ -3,6 +3,17 @@
   --dark-background-color: #1f1f1f;
   --dark-divider-color: var(--dark-accent-color);
   --dark-highlight-color: rgb(26, 115, 232, 0.26);
+  /* These colors are copied from codemirror to maintain consistency. */
+  --light-theme-line-number-color: #999999;
+  --dark-theme-line-number-color: #d0d0d0;
+  --light-theme-text-color: #000000;
+  --dark-theme-text-color: #f8f8f2;
+  /*
+   * editor styles are mostly copied from codemirror so that the text area
+   * maintains the same look.
+   */
+  --editor-line-height: 1.2em;
+  --editor-padding: 4px;
   --header-height: 48px;
   --light-accent-color: rgb(0, 0, 0, 0.04);
   --light-background-color: white;
@@ -105,7 +116,7 @@ img {
 #sidebar .mdc-form-field {
   align-items: center;
   display: flex;
-  height: var(--tab-height);
+  min-height: var(--tab-height);
   margin: 4px 8px;
   padding: 0 16px;
   -webkit-user-select: none;
@@ -270,9 +281,10 @@ img {
   margin: 0;
   max-width: calc(100% - var(--settings-input-width));
   overflow: hidden;
-  padding: 0;
+  padding: 4px 0;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
+  white-space: normal;
 }
 
 .settings-switch-ul {
@@ -284,7 +296,7 @@ img {
   border: 0px;
   border-radius: 100px;
   font-size: 14px;
-  height: 100%;
+  height: var(--tab-height);
   padding: 0;
   text-align: center;
   -webkit-user-select: auto;
@@ -378,6 +390,10 @@ header .mdc-icon-button:focus, header .mdc-icon-button:active {
   line-height: 30px;
 }
 
+.search-container.disabled {
+  opacity: 0.38;
+}
+
 #search-input-container {
   display: flex;
   width: 208px;
@@ -461,7 +477,30 @@ header.hide-controls #window-close {
   position: relative;
 }
 
-
+/* These are the styles for the screenreader mode editor */
+#editor-textarea {
+  background: var(--light-background-color);
+  color: var(--light-theme-text-color);
+  width: calc(100% - 2*var(--editor-padding));
+  height: calc(100vh - var(--header-height) - 2*var(--editor-padding));
+  resize: none;
+  padding: var(--editor-padding);
+  font-family: monospace;
+  line-height: var(--editor-line-height);
+  outline: none;
+  border: none;
+}
+.dark-theme #editor-textarea {
+  background: var(--dark-background-color);
+  color: var(--dark-theme-text-color);
+}
+#editor-textarea:focus {
+  outline: none;
+  border: none;
+}
+input[type=text][disabled] {
+  opacity: .38;
+}
 /* Markup below overrides default search input box styling. */
 input[type=search] {
   -webkit-appearance:none;
@@ -556,7 +595,7 @@ input[type=search]:focus {
 }
 
 .CodeMirror-lines {
-  line-height: 1.2em;
+  line-height: var(--editor-line-height);
 }
 
 header.search-active ~ #editor div.CodeMirror .cm-matchhighlight {

--- a/css/app.css
+++ b/css/app.css
@@ -482,8 +482,9 @@ header.hide-controls #window-close {
 #editor-textarea {
   background: var(--light-background-color);
   color: var(--light-theme-text-color);
-  width: calc(100% - 2*var(--editor-padding));
-  height: calc(100vh - var(--header-height) - 2*var(--editor-padding));
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
   resize: none;
   padding: var(--editor-padding);
   font-family: monospace;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link href="css/theme-dark.css" rel="stylesheet">
   <link href="css/theme-light.css" rel="stylesheet">
 </head>
-<body>
+<body i18n-values="aria-label:screenreaderModeHelp">
   <div id="window-container">
     <div id="sidebar">
       <div id="sidebar-resizer"></div>
@@ -109,6 +109,18 @@
                 <div class="mdc-switch__thumb-underlay">
                   <div class="mdc-switch__thumb">
                     <input type="checkbox" id="setting-alwaysontop"
+                        class="mdc-switch__native-control" role="switch">
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li>
+              <label for="setting-screenreadermode" i18n-content="screenreaderModeSetting"></label>
+              <div class="mdc-switch" id="setting-screenreadermode-switch">
+                <div class="mdc-switch__track"></div>
+                <div class="mdc-switch__thumb-underlay">
+                  <div class="mdc-switch__thumb">
+                    <input type="checkbox" id="setting-screenreadermode"
                         class="mdc-switch__native-control" role="switch">
                   </div>
                 </div>
@@ -261,6 +273,7 @@
   <script src="js/analytics.js" type="text/javascript"></script>
   <script src="js/app.js" type="text/javascript"></script>
   <script src="js/editor-cm.js" type="text/javascript"></script>
+  <script src="js/editor-ta.js" type="text/javascript"></script>
   <script src="js/i18n-template.js" type="text/javascript"></script>
   <script src="js/search.js" type="text/javascript"></script>
   <script src="js/settings.js" type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link href="css/theme-dark.css" rel="stylesheet">
   <link href="css/theme-light.css" rel="stylesheet">
 </head>
-<body i18n-values="aria-label:screenreaderModeHelp">
+<body i18n-values="aria-label:screenReaderModeHelp">
   <div id="window-container">
     <div id="sidebar">
       <div id="sidebar-resizer"></div>
@@ -115,7 +115,7 @@
               </div>
             </li>
             <li>
-              <label for="setting-screenreadermode" i18n-content="screenreaderModeSetting"></label>
+              <label for="setting-screenreadermode" i18n-content="screenReaderModeSetting"></label>
               <div class="mdc-switch" id="setting-screenreadermode-switch">
                 <div class="mdc-switch__track"></div>
                 <div class="mdc-switch__thumb-underlay">

--- a/js/app.js
+++ b/js/app.js
@@ -23,18 +23,8 @@ function TextApp() {
 TextApp.prototype.init = function() {
   this.settings_ = new Settings();
   this.analytics_ = new Analytics();
-  this.editor_ = new Editor($('#editor')[0], this.settings_);
-  this.dialogController_ = new DialogController($('#dialog-container'),
-                                                this.editor_);
-  this.tabs_ = new Tabs(this.editor_, this.dialogController_, this.settings_);
-
-  this.menuController_ = new MenuController(this.tabs_);
-  this.searchController_ = new SearchController(this.editor_.getSearch());
-  this.settingsController_ = new SettingsController(this.settings_);
-  this.windowController_ = new WindowController(
-      this.editor_, this.settings_, this.analytics_, this.tabs_);
-  this.hotkeysController_ = new HotkeysController( this.windowController_,
-      this.tabs_, this.editor_, this.settings_, this.analytics_);
+  // Editor is initalised after settings are ready.
+  this.editor_ = null;
 
   if (this.settings_.isReady()) {
     this.onSettingsReady_();
@@ -43,9 +33,6 @@ TextApp.prototype.init = function() {
   }
   $(document).bind('settingschange', this.onSettingsChanged_.bind(this));
 
-  chrome.runtime.getBackgroundPage(function(bg) {
-    bg.background.onWindowReady(this);
-  }.bind(this));
 };
 
 /**
@@ -82,9 +69,90 @@ TextApp.prototype.setTheme = function() {
 };
 
 /**
+ * Remove the editor so it can be reinitialized.
+ * @param editor The DOM element containing the editor.
+ */
+TextApp.prototype.removeEditor = function(editor) {
+  // Let the object do any clean up it needs.
+  if (this.editor_ !== null) {
+    this.editor_.destory();
+  }
+
+  // Clear the DOM
+  while (editor.firstElementChild !== null) {
+    editor.firstElementChild.remove();
+  }
+};
+
+/**
  * Called when all the services have started and settings are loaded.
  */
 TextApp.prototype.onSettingsReady_ = function() {
+  this.settingsController_ = new SettingsController(this.settings_);
+
+  this.initEditor_();
+
+  this.analytics_.setEnabled(this.settings_.get('analytics'));
+  this.analytics_.reportSettings(this.settings_);
+  this.windowController_.setAlwaysOnTop(this.settings_.get('alwaysontop'));
+
+  chrome.runtime.getBackgroundPage(function(bg) {
+    bg.background.onWindowReady(this);
+  }.bind(this));
+};
+
+/**
+ * Create a new editor and load all settings.
+ */
+TextApp.prototype.initEditor_ = function() {
+  // Remove any editor that already exists.
+  if (this.editor_ !== null) {
+    const editor = document.getElementById('editor');
+    this.removeEditor(editor);
+  }
+
+  if (this.settings_.get('screenreadermode')) {
+    this.editor_ = new EditorTextArea(editor, this.settings_);
+  } else {
+    this.editor_ = new EditorCodeMirror(editor, this.settings_);
+  }
+
+  if (!this.tabs_) {
+    // If tabs doesn't exist this is the first editor being created, if so
+    // create all the needed controllers.
+    this.dialogController_ = new DialogController(
+        $('#dialog-container'), this.editor_);
+    this.tabs_ = new Tabs(this.editor_, this.dialogController_, this.settings_);
+    this.menuController_ = new MenuController(this.tabs_);
+    this.windowController_ = new WindowController(
+        this.editor_, this.settings_, this.analytics_, this.tabs_);
+    this.hotkeysController_ = new HotkeysController(this.windowController_,
+        this.tabs_, this.editor_, this.settings_, this.analytics_);
+    this.searchController_ = new SearchController(this.editor_.getSearch());
+  } else {
+    // If tabs already exists, just replace the editor rather then creating a
+    // new Tabs object instance, this way we don't lose any tabs that were open.
+    this.tabs_.updateEditor(this.editor_);
+
+    // Controllers should be only created once.
+    // On any subsequent editor changes they should be notified of the editor
+    // change rather then reconstructed. This is to prevent these objects from
+    // creating spurious event handlers that all run in tandem.
+    this.windowController_.updateEditor(this.editor_);
+    this.hotkeysController_.updateEditor(this.editor_);
+    this.searchController_.updateEditor(this.editor_);
+  }
+
+  // Unlock all settings.
+  this.settings_.enableAll();
+
+  // Lock any settings the editor doesn't support.
+  const lockedSettings = this.editor_.lockedSettings();
+  for (const [setting, value] of Object.entries(lockedSettings)) {
+    this.settings_.disable(setting, value);
+  }
+
+  // Load settings.
   this.setTheme();
   this.editor_.setFontSize(this.settings_.get('fontsize'));
   this.editor_.showHideLineNumbers(this.settings_.get('linenumbers'));
@@ -92,9 +160,6 @@ TextApp.prototype.onSettingsReady_ = function() {
   this.editor_.replaceTabWithSpaces(this.settings_.get('spacestab'));
   this.editor_.setTabSize(this.settings_.get('tabsize'));
   this.editor_.setWrapLines(this.settings_.get('wraplines'));
-  this.analytics_.setEnabled(this.settings_.get('analytics'));
-  this.analytics_.reportSettings(this.settings_);
-  this.windowController_.setAlwaysOnTop(this.settings_.get('alwaysontop'));
 };
 
 /**
@@ -135,9 +200,21 @@ TextApp.prototype.onSettingsChanged_ = function(e, key, value) {
     case 'wraplines':
       this.editor_.setWrapLines(value);
       break;
+
+    case 'screenreadermode':
+      // This recreates a new editor and inserts it into the dom whenever the
+      // setting is changed, this is quite slow but the complexity of keeping
+      // both alive and switching them out seemed excessive given the frequency
+      // that this setting will likely be changed.
+      this.initEditor_();
+      this.editor_.setSession(this.tabs_.currentTab_.getSession());
+      break;
   }
 };
 
-var textApp = new TextApp();
+const textApp = new TextApp();
 
-$(document).ready(textApp.init.bind(textApp));
+document.addEventListener('DOMContentLoaded', function() {
+  textApp.init();
+});
+

--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -79,10 +79,6 @@ HotkeysController.prototype.onKeydown_ = function(e) {
         this.windowController_.close();
         return false;
 
-      case 'Z':
-        this.editor_.redo();
-        return false;
-
       case '0':
       case ')':
         this.settings_.reset('fontsize');

--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -15,6 +15,13 @@ function HotkeysController(windowController, tabs, editor, settings, analytics) 
 };
 
 /**
+ * Update the editor.
+ */
+HotkeysController.prototype.updateEditor = function(editor) {
+  this.editor_ = editor;
+}
+
+/**
  * Handles hotkey combination if present in keydown event.
  * Some hotkeys are handled by CodeMirror directly. Among them:
  * Ctrl-C, Ctrl-V, Ctrl-X, Ctrl-Z, Ctrl-Y, Ctrl-A

--- a/js/controllers/search.js
+++ b/js/controllers/search.js
@@ -16,6 +16,10 @@ function SearchController(search) {
   $('.search-container').focusout(this.deactivateSearch_.bind(this));
 }
 
+SearchController.prototype.updateEditor = function(editor) {
+  this.search_ = editor.getSearch();
+}
+
 SearchController.prototype.updateSearchCount_ = function() {
   if ($('#search-input').val().length === 0) {
     $('#search-counting').text('');

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -25,6 +25,13 @@ function WindowController(editor, settings, analytics, tabs) {
 }
 
 /**
+ * Update the editor.
+ */
+WindowController.prototype.updateEditor = function(editor) {
+  this.editor_ = editor;
+}
+
+/**
  * Performs all the required initialization for the UI.
  * @private
  */

--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -329,7 +329,7 @@ EditorCodeMirror.prototype.enable = function() {
 /**
  * Prepare the Editor to be killed and removed from the DOM
  */
-EditorCodeMirror.prototype.destory = function() {
-  // detach the current doc so it can be reset in future
+EditorCodeMirror.prototype.destroy = function() {
+  // Detach the current doc so it can be reset in future.
   this.cm_.swapDoc(new CodeMirror.Doc(''));
 };

--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -183,20 +183,20 @@ EditorCodeMirror.EXTENSION_TO_MODE = {
     'yaml': 'yaml'};
 
 /**
- * @param {string} opt_content
- * @return {EditSession}
- * Create an edit session for a new file. Each tab should have its own session.
- */
-EditorCodeMirror.prototype.newSession = function(opt_content) {
-  var session = new CodeMirror.Doc(opt_content || '');
-  return session;
-};
-/**
- * @param {EditSession} session
+ * @param {SessionDescriptor} session
  * Change the current session, usually to switch to another tab.
  */
 EditorCodeMirror.prototype.setSession = function(session) {
-  this.cm_.swapDoc(session);
+  this.cm_.swapDoc(session.codemirror);
+  this.currentSession_ = session;
+};
+
+/**
+ * Returns all settings which are locked to a certain value
+ * when this editor is open.
+ */
+EditorCodeMirror.prototype.lockedSettings = function() {
+  return {};
 };
 
 /**
@@ -208,7 +208,10 @@ EditorCodeMirror.prototype.getSearch = function() {
 };
 
 EditorCodeMirror.prototype.onChange = function() {
-  $.event.trigger('docchange', this.cm_.getDoc());
+  $.event.trigger('docchange', {
+    type: 'codemirror',
+    session: this.currentSession_
+  });
 };
 
 EditorCodeMirror.prototype.undo = function() {
@@ -224,10 +227,11 @@ EditorCodeMirror.prototype.focus = function() {
 };
 
 /**
- * @param {Session} session
+ * @param {SessionDescriptor} session
  * @param {string} extension
  */
 EditorCodeMirror.prototype.setMode = function(session, extension) {
+  session = session.codemirror;
   var mode = EditorCodeMirror.EXTENSION_TO_MODE[extension];
   if (mode) {
     var currentSession = null;
@@ -322,5 +326,10 @@ EditorCodeMirror.prototype.enable = function() {
   this.cm_.focus();
 };
 
-var Editor = EditorCodeMirror;
-
+/**
+ * Prepare the Editor to be killed and removed from the DOM
+ */
+EditorCodeMirror.prototype.destory = function() {
+  // detach the current doc so it can be reset in future
+  this.cm_.swapDoc(new CodeMirror.Doc(''));
+};

--- a/js/editor-ta.js
+++ b/js/editor-ta.js
@@ -68,7 +68,7 @@ EditorTextArea.prototype.lockedSettings = function() {
  * @return {Search}
  */
 EditorTextArea.prototype.getSearch = function() {
-  // unsupported.
+  // Unsupported.
 };
 
 
@@ -84,10 +84,7 @@ EditorTextArea.prototype.undo = function() {
 };
 
 EditorTextArea.prototype.redo = function() {
-  // This is handled by the text area defaults, but control-shift-z
-  // isn't supported by a textarea, so we still need this function to trigger a
-  // redo for that keyboard shortcut.
-  document.execCommand('redo');
+  // This is handled by the text area defaults.
 };
 
 EditorTextArea.prototype.focus = function() {
@@ -95,7 +92,7 @@ EditorTextArea.prototype.focus = function() {
 };
 
 /**
- * Set the syntac highlighting mode of the text editor
+ * Set the syntax highlighting mode of the text editor.
  * @param {Session} session
  * @param {string} extension
  */
@@ -115,7 +112,7 @@ EditorTextArea.prototype.setFontSize = function(fontSize) {
  * @param {number} size
  */
 EditorTextArea.prototype.setTabSize = function(size) {
-  // unsupported.
+  // Unsupported.
 };
 
 /**
@@ -133,47 +130,41 @@ EditorTextArea.prototype.setTheme = function() {
  * @param {boolean} val
  */
 EditorTextArea.prototype.showHideLineNumbers = function(val) {
-  // unsupported.
+  // Unsupported.
 };
 
 /**
  * @param {boolean} val
  */
 EditorTextArea.prototype.setWrapLines = function(val) {
-  // unsupported.
+  // Unsupported.
 };
 
 /**
  * @param {boolean} val
  */
 EditorTextArea.prototype.setSmartIndent = function(val) {
-  // unsupported.
+  // Unsupported.
 };
 
 /**
  * @param {boolean} val
  */
 EditorTextArea.prototype.replaceTabWithSpaces = function(val) {
-  // unsupported.
+  // Unsupported.
 };
 
-/**
- * Make the textarea unfocusable and hide cursor.
- */
 EditorTextArea.prototype.disable = function() {
-  // unsupported.
+  // Unsupported.
 };
 
-/**
- * Focus textarea again.
- */
 EditorTextArea.prototype.enable = function() {
-  // unsupported.
+  // Unsupported.
 };
 
 /**
  * Prepare the Editor to be killed and then remove it from the DOM.
  */
-EditorTextArea.prototype.destory = function() {
-
+EditorTextArea.prototype.destroy = function() {
+  // Text area does not have any destruction logic.
 };

--- a/js/editor-ta.js
+++ b/js/editor-ta.js
@@ -1,0 +1,179 @@
+/**
+ * @constructor
+ * @param {DOM} editorElement
+ * @param {Settings} settings
+ */
+function EditorTextArea(editorElement, settings) {
+  this.root_ = editorElement;
+  this.settings_ = settings;
+  this.currentSession_ = null;
+
+  // We need a named reference to this arrow function so we can remove it
+  // as an EventListener.
+  this.onInput = () => {
+    this.onChange();
+  }
+
+  this.attachTextArea(document.createElement('textarea'));
+  this.setTheme();
+}
+
+/**
+ * @param {HTMLElement} textarea
+ * Attaches a given textarea to the editor so it may be edited.
+ */
+EditorTextArea.prototype.attachTextArea = function(textarea) {
+  const initFontSize = this.settings_.get('fontsize') + 'px';
+  // Detach previous text area.
+  if (this.textarea_) {
+    this.textarea_.remove();
+    this.textarea_.removeEventListener('input', this.onInput);
+  }
+
+  textarea.setAttribute('id', 'editor-textarea');
+  textarea.setAttribute('spellcheck', 'false');
+  textarea.style.fontSize = initFontSize;
+  textarea.addEventListener('input', this.onInput);
+
+  this.textarea_ = textarea;
+  this.root_.appendChild(this.textarea_ );
+}
+
+/**
+ * Change the current session, usually to switch to another tab.
+ * @param {SessionDescriptor} session
+ */
+EditorTextArea.prototype.setSession = function(session) {
+  this.attachTextArea(session.textarea);
+  this.currentSession_ = session;
+};
+
+/**
+ * Returns all settings which are locked to a certain value
+ * when this editor is open.
+ */
+EditorTextArea.prototype.lockedSettings = function() {
+  return {
+    'linenumbers': false,
+    'smartindent': false,
+    'spacestab': false,
+    'tabsize': 3,
+    'wraplines': true,
+    'search': false
+  }
+};
+
+/**
+ * Return search object.
+ * @return {Search}
+ */
+EditorTextArea.prototype.getSearch = function() {
+  // unsupported.
+};
+
+
+EditorTextArea.prototype.onChange = function() {
+  $.event.trigger('docchange', {
+    type: 'textarea',
+    session: this.currentSession_
+  });
+};
+
+EditorTextArea.prototype.undo = function() {
+  // This is handled by the text area defaults.
+};
+
+EditorTextArea.prototype.redo = function() {
+  // This is handled by the text area defaults, but control-shift-z
+  // isn't supported by a textarea, so we still need this function to trigger a
+  // redo for that keyboard shortcut.
+  document.execCommand('redo');
+};
+
+EditorTextArea.prototype.focus = function() {
+  this.textarea_.focus();
+};
+
+/**
+ * Set the syntac highlighting mode of the text editor
+ * @param {Session} session
+ * @param {string} extension
+ */
+EditorTextArea.prototype.setMode = function(session, extension) {
+  // Textarea does not support any modes other than plain text.
+};
+
+/**
+ * Update font size from settings.
+ * @param {number} fontSize
+ */
+EditorTextArea.prototype.setFontSize = function(fontSize) {
+  this.textarea_.style.fontSize = fontSize + 'px';
+};
+
+/**
+ * @param {number} size
+ */
+EditorTextArea.prototype.setTabSize = function(size) {
+  // unsupported.
+};
+
+/**
+ * @param {string} theme
+ */
+EditorTextArea.prototype.setTheme = function() {
+  if (this.settings_.get('theme') === 'dark') {
+    this.root_.classList.add('dark-theme');
+  } else {
+    this.root_.classList.remove('dark-theme');
+  }
+};
+
+/**
+ * @param {boolean} val
+ */
+EditorTextArea.prototype.showHideLineNumbers = function(val) {
+  // unsupported.
+};
+
+/**
+ * @param {boolean} val
+ */
+EditorTextArea.prototype.setWrapLines = function(val) {
+  // unsupported.
+};
+
+/**
+ * @param {boolean} val
+ */
+EditorTextArea.prototype.setSmartIndent = function(val) {
+  // unsupported.
+};
+
+/**
+ * @param {boolean} val
+ */
+EditorTextArea.prototype.replaceTabWithSpaces = function(val) {
+  // unsupported.
+};
+
+/**
+ * Make the textarea unfocusable and hide cursor.
+ */
+EditorTextArea.prototype.disable = function() {
+  // unsupported.
+};
+
+/**
+ * Focus textarea again.
+ */
+EditorTextArea.prototype.enable = function() {
+  // unsupported.
+};
+
+/**
+ * Prepare the Editor to be killed and then remove it from the DOM.
+ */
+EditorTextArea.prototype.destory = function() {
+
+};

--- a/js/settings.js
+++ b/js/settings.js
@@ -26,6 +26,7 @@ Settings.AREA = 'sync';
  * @type {Object.<string, Object>}
  */
 Settings.SETTINGS = {
+  'screenreadermode': {'default': false, 'type': 'boolean', 'widget': 'checkbox'},
   'analytics': {'default': false, 'type': 'boolean', 'widget': 'checkbox'},
   'alwaysontop': {'default': false, 'type': 'boolean', 'widget': 'checkbox'},
   'fontsize': {'default': 14, 'type': 'number', 'widget': 'number'},
@@ -36,7 +37,8 @@ Settings.SETTINGS = {
   'spacestab': {'default': true, 'type': 'boolean', 'widget': 'checkbox'},
   'tabsize': {'default': 4, 'type': 'integer', 'widget': 'number'},
   'theme': {'default': 'default', 'type': 'string', 'widget': 'radio'},
-  'wraplines': {'default': true, 'type': 'boolean', 'widget': 'checkbox'}
+  'wraplines': {'default': true, 'type': 'boolean', 'widget': 'checkbox'},
+  'search': {'default': true, 'type': 'boolean', 'widget': 'search'}
 };
 
 Settings.prototype.removeOldSettings_ = function() {
@@ -101,3 +103,52 @@ Settings.prototype.onChanged_ = function(changes, areaName) {
   }
 };
 
+/**
+ * Enables all settings to be editable.
+ */
+Settings.prototype.enableAll = function() {
+  for (const [key, setting] of Object.entries(Settings.SETTINGS)) {
+    const widget = setting.widget;
+
+    if (widget === 'checkbox') {
+      const elem = document.getElementById(`setting-${key}-switch`);
+      elem.classList.remove('mdc-switch--disabled');
+      elem.querySelector('input').removeAttribute('disabled');
+    } else if (widget === 'number') {
+      const elem = document.getElementById(`setting-${key}`);
+      elem.removeAttribute('disabled');
+    } else if (widget === 'search') {
+      const elem = document.getElementById('search-input');
+      elem.removeAttribute('disabled');
+      const container = document.querySelector('.search-container');
+      container.classList.remove('disabled');
+    }
+    // Else it can't be disabled.
+  }
+}
+
+
+/**
+ * Locks a setting to particular value and prevents the user from changing it.
+ * Can only lock a setting with a checkbox or a number widget.
+ */
+Settings.prototype.disable = function(setting, value) {
+  this.set(setting, value);
+
+  const widget = Settings.SETTINGS[setting].widget;
+  if (widget === 'checkbox') {
+    const elem = document.getElementById(`setting-${setting}-switch`);
+    elem.classList.add('mdc-switch--disabled');
+    elem.querySelector('input').setAttribute('disabled', 'true');
+  } else if (widget === 'number') {
+    const elem = document.getElementById(`setting-${setting}`);
+    elem.setAttribute('disabled', 'true');
+  } else if (widget === 'search') {
+    const elem = document.getElementById('search-input');
+    elem.setAttribute('disabled', 'true');
+    const container = document.querySelector('.search-container');
+    container.classList.add('disabled');
+  }
+  // Do nothing if widget isn't supported.
+  // This case is hit by settings with no widget or a radio widget.
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -38,7 +38,7 @@ Settings.SETTINGS = {
   'tabsize': {'default': 4, 'type': 'integer', 'widget': 'number'},
   'theme': {'default': 'default', 'type': 'string', 'widget': 'radio'},
   'wraplines': {'default': true, 'type': 'boolean', 'widget': 'checkbox'},
-  'search': {'default': true, 'type': 'boolean', 'widget': 'search'}
+  'search': {'default': true, 'type': 'boolean', 'widget': 'search'},
 };
 
 Settings.prototype.removeOldSettings_ = function() {
@@ -109,24 +109,30 @@ Settings.prototype.onChanged_ = function(changes, areaName) {
 Settings.prototype.enableAll = function() {
   for (const [key, setting] of Object.entries(Settings.SETTINGS)) {
     const widget = setting.widget;
+    let elem;
 
-    if (widget === 'checkbox') {
-      const elem = document.getElementById(`setting-${key}-switch`);
-      elem.classList.remove('mdc-switch--disabled');
-      elem.querySelector('input').removeAttribute('disabled');
-    } else if (widget === 'number') {
-      const elem = document.getElementById(`setting-${key}`);
-      elem.removeAttribute('disabled');
-    } else if (widget === 'search') {
-      const elem = document.getElementById('search-input');
-      elem.removeAttribute('disabled');
-      const container = document.querySelector('.search-container');
-      container.classList.remove('disabled');
+    switch(widget) {
+      case 'checkbox':
+        elem = document.getElementById(`setting-${key}-switch`);
+        elem.classList.remove('mdc-switch--disabled');
+        elem.querySelector('input').removeAttribute('disabled');
+        break;
+      case 'number':
+        elem = document.getElementById(`setting-${key}`);
+        elem.removeAttribute('disabled');
+        break;
+      case 'search':
+        elem = document.getElementById('search-input');
+        elem.removeAttribute('disabled');
+        const container = document.querySelector('.search-container');
+        container.classList.remove('disabled');
+        break;
+      default:
+        // Else it can't be disabled.
+        break;
     }
-    // Else it can't be disabled.
   }
 }
-
 
 /**
  * Locks a setting to particular value and prevents the user from changing it.
@@ -134,21 +140,28 @@ Settings.prototype.enableAll = function() {
  */
 Settings.prototype.disable = function(setting, value) {
   this.set(setting, value);
+  let elem;
 
   const widget = Settings.SETTINGS[setting].widget;
-  if (widget === 'checkbox') {
-    const elem = document.getElementById(`setting-${setting}-switch`);
-    elem.classList.add('mdc-switch--disabled');
-    elem.querySelector('input').setAttribute('disabled', 'true');
-  } else if (widget === 'number') {
-    const elem = document.getElementById(`setting-${setting}`);
-    elem.setAttribute('disabled', 'true');
-  } else if (widget === 'search') {
-    const elem = document.getElementById('search-input');
-    elem.setAttribute('disabled', 'true');
-    const container = document.querySelector('.search-container');
-    container.classList.add('disabled');
+  switch (widget) {
+    case 'checkbox':
+      elem = document.getElementById(`setting-${setting}-switch`);
+      elem.classList.add('mdc-switch--disabled');
+      elem.querySelector('input').setAttribute('disabled', 'true');
+      break;
+    case 'number':
+      elem = document.getElementById(`setting-${setting}`);
+      elem.setAttribute('disabled', 'true');
+      break;
+    case 'search':
+      elem = document.getElementById('search-input');
+      elem.setAttribute('disabled', 'true');
+      const container = document.querySelector('.search-container');
+      container.classList.add('disabled');
+      break;
+    default:
+      // Do nothing if widget isn't supported.
+      // This case is hit by settings with no widget or a radio widget.
+      break;
   }
-  // Do nothing if widget isn't supported.
-  // This case is hit by settings with no widget or a radio widget.
 }

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -470,18 +470,18 @@ Tabs.prototype.saveEntry_ = function(tab, entry, opt_callback) {
 };
 
 /**
- * @param {Event} event The DocChange event object.
- * @param {Object} eventData The data passed with the DocChange event. This
- *   object contains where the event came from, i.e textarea or codemirror, which
- *   helps the syncUnifiedSession function determine which of the editors is the
- *   source of truth. It also contains the current session of the editor so this
- *   function can check to make sure Tabs state is still accurate.
  * The event handler which is called when a DocChange event is caught, this
  * handler registers the change and then syncs the codemirror and textarea
  * instances so they both contain the same text.
+ * @param {Event} event The DocChange event object.
+ * @param {Object} eventData The data passed with the DocChange event. This
+ *   object contains where the event came from, i.e, textarea or codemirror, which
+ *   helps the syncUnifiedSession function determine which of the editors is the
+ *   source of truth. It also contains the current session of the editor so this
+ *   function can check to make sure Tabs state is still accurate.
  */
 Tabs.prototype.onDocChanged_ = function(event, eventData) {
-  // Assume that updates are coming from the current tab, if they arn't
+  // Assume that updates are coming from the current tab, if they aren't
   // we have no real way to recover so failing here is acceptable.
   var tab = this.currentTab_;
   tab.changed();

--- a/js/util.js
+++ b/js/util.js
@@ -1,9 +1,9 @@
 var util = {};
 
 /**
- * A object which describes a edit session. Each session contains a instance of
- * how it should be represented to codemirror and to textarea so the two can be
- * easily switched between.
+ * A object which describes an edit session. Each session contains an instance
+ * of how it should be represented to codemirror and to textarea so the two can
+ * be easily switched between.
  * @typedef {{
  *            textarea:HTMLElement,
  *            codemirror:Object,
@@ -125,11 +125,13 @@ util.createUnifiedSession = function(opt_content) {
  * such as the codemirror instance generates a change, it's registered here and
  * copied over to the other formats (such as textarea) so all of the formats
  * have the correct text. This means if you switch between modes you don't lose
- * any text and the undo stack is consistent (the redo stack may
- * diverge as all edits are treated as direct edits when transfered from one
- * format to the other).
+ * any text. This does cause the other editer to lose it's undo/redo stack,
+ * textarea loses all history whereas codemirror tries and interpert each
+ * changed character as a single edit, which blows the undo stack out.
  */
 util.syncUnifiedSession = function(session, updated, lineEndings) {
+  // TODO: Update this so that updating 1 editor syncs to the other editors in a
+  // way that preserves undo/redo stacks.
   switch(updated) {
     case 'codemirror':
       session.textarea.value = session.codemirror.getValue(lineEndings);

--- a/js/util.js
+++ b/js/util.js
@@ -1,6 +1,17 @@
 var util = {};
 
 /**
+ * A object which describes a edit session. Each session contains a instance of
+ * how it should be represented to codemirror and to textarea so the two can be
+ * easily switched between.
+ * @typedef {{
+ *            textarea:HTMLElement,
+ *            codemirror:Object,
+ *          }}
+ */
+var SessionDescriptor;
+
+/**
  * @param {Event} e
  * @return {string} Human-readable error description.
  */
@@ -76,11 +87,11 @@ util.getExtension = function(fileName) {
   }
 };
 
-/*
+/**
  * @param {?string} [text] Text content.
  * @return {string} Line endings.
  * Returns guessed line endings or LF if not successful.
-*/
+ */
 util.guessLineEndings = function(text) {
   if (!text) {
     return '\n';
@@ -90,3 +101,41 @@ util.guessLineEndings = function(text) {
 
   return (hasCRLF ? '\r\n' : '\n');
 };
+
+/**
+ * @param {?string} opt_content Optional content.
+ * @return {SessionDescriptor}
+ * Creates a unified session that can be read from any supported editor.
+ */
+util.createUnifiedSession = function(opt_content) {
+  const textarea = document.createElement('textarea');
+  textarea.value = opt_content || '';
+
+  return {
+    codemirror: new CodeMirror.Doc(opt_content || ''),
+    textarea: textarea,
+  };
+}
+
+/**
+ * @param {SessionDescriptor} session
+ * @param {string} updated Which text source is the source of truth.
+ * @param {string} lineEndings What to use as a line ending
+ * Syncs the multiple formats of a unified session. If one format of the session
+ * such as the codemirror instance generates a change, it's registered here and
+ * copied over to the other formats (such as textarea) so all of the formats
+ * have the correct text. This means if you switch between modes you don't lose
+ * any text and the undo stack is consistent (the redo stack may
+ * diverge as all edits are treated as direct edits when transfered from one
+ * format to the other).
+ */
+util.syncUnifiedSession = function(session, updated, lineEndings) {
+  switch(updated) {
+    case 'codemirror':
+      session.textarea.value = session.codemirror.getValue(lineEndings);
+      break;
+    case 'textarea':
+      session.codemirror.setValue(session.textarea.value);
+      break;
+  }
+}


### PR DESCRIPTION
DO NOT MERGE: the new messages need to be translated and landed in before this PR can land.

Adds a toggle in settings called screen reader mode which switches the codemirror instance out for a plain textarea. This is provide a editable text surface for users using a screen reader which correctly announces edits. Codemirror does not provide this functionality and is in a state where adding this functionality would be very difficult.