### PR TITLE
set proper keyboard shortcuts for Save and Save As actions

### DIFF
--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -62,11 +62,13 @@ HotkeysController.prototype.onKeydown_ = function(e) {
         return false;
 
       case 's':
-        this.tabs_.save();
-        return false;
-
       case 'S':
-        this.tabs_.saveAs();
+        if (e.shiftKey) {
+          this.tabs_.saveAs();
+        }
+        else {
+          this.tabs_.save();
+        }
         return false;
 
       case 'w':


### PR DESCRIPTION
As it was mentioned in this [issue](https://github.com/GoogleChromeLabs/text-app/issues/523), keyboard shortcuts for `save` and `save as` actions do not behave like in most of other applications, because they listen to the CapsLock.

After this change it doesn't matter anymore if the CapsLock is turned on or off, as the `save as` action is invoked by pressing _Ctrl+Shift+s_ or _Ctrl+Shift+S_ keys combination.