### PR TITLE
Fix emoji rendering

### DIFF
--- a/third_party/CodeMirror/lib/codemirror.js
+++ b/third_party/CodeMirror/lib/codemirror.js
@@ -7637,7 +7637,7 @@ function defineOptions(CodeMirror) {
     for (var i = newBreaks.length - 1; i >= 0; i--)
       { replaceRange(cm.doc, val, newBreaks[i], Pos(newBreaks[i].line, newBreaks[i].ch + val.length)) }
   })
-  option("specialChars", /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200f\u2028\u2029\ufeff]/g, function (cm, val, old) {
+  option("specialChars", /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200c\u200e\u200f\u2028\u2029\ufeff]/g, function (cm, val, old) {
     cm.state.specialChars = new RegExp(val.source + (val.test("\t") ? "" : "|\t"), "g")
     if (old != Init) { cm.refresh() }
   })


### PR DESCRIPTION
Manual cherrypick of https://github.com/codemirror/CodeMirror/commit/2571b4ad08e007c246d73bdd973892bf5dd7b02e

Removes zero width joiner from special chars which fixes emoji rendering

(This version just changes the pre-built code mirror.js rather than the raw source)