### PR TITLE
Make Default theme choose system prefered theme if Chrome version >= 103

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,6 +14,17 @@ function TextApp() {
   this.windowController_ = null;
 
   this.hasFrame_ = false;
+
+  /**
+   * If true, the "default" setting for the color theme chooses light/dark
+   * depending on the system's preferred color scheme.
+   * If false, the "default" setting is a dark side nav and a light editor.
+   *
+   * @type {boolean}
+   */
+  this.enableSystemTheme_ = false;
+  /** The media query list to detect if the preferred color scheme is dark. */
+  this.colorSchemeMatcherDark_ = null;
 }
 
 /**
@@ -21,6 +32,9 @@ function TextApp() {
  * here.
  */
 TextApp.prototype.init = function() {
+  this.enableSystemTheme_ =
+      parseInt(navigator.appVersion.match(/Chrome\/(\d+)\./)[1], 10) >= 103;
+
   this.settings_ = new Settings();
   // Editor is initalised after settings are ready.
   this.editor_ = null;
@@ -31,6 +45,14 @@ TextApp.prototype.init = function() {
     $(document).bind('settingsready', this.onSettingsReady_.bind(this));
   }
   $(document).bind('settingschange', this.onSettingsChanged_.bind(this));
+
+  if (this.enableSystemTheme_) {
+    this.colorSchemeMatcherDark_ =
+        window.matchMedia('(prefers-color-scheme: dark)');
+    this.colorSchemeMatcherDark_.addEventListener('change', () => {
+      if (this.settings_.get('theme') === 'default') this.setTheme();
+    });
+  }
 };
 
 /**
@@ -62,6 +84,11 @@ TextApp.prototype.getFilesToRetain = function() {
 
 TextApp.prototype.setTheme = function() {
   var theme = this.settings_.get('theme');
+
+  if (this.enableSystemTheme_ && theme === 'default') {
+    theme = this.colorSchemeMatcherDark_.matches ? 'dark' : 'light';
+  }
+
   this.windowController_.setTheme(theme);
   this.editor_.setTheme(theme);
 };

--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -126,7 +126,7 @@ function EditorCodeMirror(editorElement, settings) {
       });
   this.cm_.setSize(null, 'auto');
   this.cm_.on('change', this.onChange.bind(this));
-  this.setTheme();
+  this.setTheme(settings.get('theme'));
   this.search_ = new Search(this.cm_);
   // Mimic Sublime behaviour there.
   this.defaultTabHandler_ = CodeMirror.commands.defaultTab;
@@ -264,10 +264,11 @@ EditorCodeMirror.prototype.setTabSize = function(size) {
 };
 
 /**
- * @param {string} theme
+ * @param {string} theme The color theme to change to. Default light.
  */
 EditorCodeMirror.prototype.setTheme = function(theme) {
-  this.cm_.setOption('theme', theme || 'default');
+  if (theme !== 'dark') theme = 'light';
+  this.cm_.setOption('theme', theme);
 };
 
 /**

--- a/js/editor-ta.js
+++ b/js/editor-ta.js
@@ -15,7 +15,7 @@ function EditorTextArea(editorElement, settings) {
   }
 
   this.attachTextArea(document.createElement('textarea'));
-  this.setTheme();
+  this.setTheme(settings.get('theme'));
 }
 
 /**
@@ -116,10 +116,10 @@ EditorTextArea.prototype.setTabSize = function(size) {
 };
 
 /**
- * @param {string} theme
+ * @param {string} theme The color theme to change to. Default light.
  */
-EditorTextArea.prototype.setTheme = function() {
-  if (this.settings_.get('theme') === 'dark') {
+EditorTextArea.prototype.setTheme = function(theme) {
+  if (theme === 'dark') {
     this.root_.classList.add('dark-theme');
   } else {
     this.root_.classList.remove('dark-theme');


### PR DESCRIPTION
The Chrome version is used like a feature flag.

Behavior when disabled (version < 103):

 * The Default theme is a black side nav and a white editor.

Behavior when enabled (version >= 103):

 * The Default theme is dark or light depending on the system's preferred color scheme.

No UI string changes yet.