### PR TITLE
Increase contrast of line number and file name

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -5,8 +5,6 @@
   --dark-highlight-color: rgb(26, 115, 232, 0.26);
   --disabled-opacity: 0.38;
   /* These colors are copied from codemirror to maintain consistency. */
-  --light-theme-line-number-color: #999999;
-  --dark-theme-line-number-color: #d0d0d0;
   --light-theme-text-color: #000000;
   --dark-theme-text-color: #f8f8f2;
   /*
@@ -441,7 +439,7 @@ header.search-active .search-navigation-button {
 }
 
 #title-filename {
-  color: #777;
+  color: #5f6368;
   display: flex;
   flex: 1;
   font-size: 15px;

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -28,6 +28,10 @@ body[theme="dark"] #settings-list input[type="text"] {
   color: #EBEBEB;
 }
 
+body[theme="dark"] #title-filename {
+  color: #bdc1c6;
+}
+
 /* Based on CodeMirror dark theme */
 /* Based on Sublime Text's dark theme */
 
@@ -42,7 +46,7 @@ body[theme="dark"] #settings-list input[type="text"] {
 }
 
 .cm-s-dark div.CodeMirror-selected {background: #49483E !important;}
-.cm-s-dark .CodeMirror-linenumber {color: #d0d0d0;}
+.cm-s-dark .CodeMirror-linenumber {color: #bdc1c6;}
 .cm-s-dark .CodeMirror-cursor {border-left: 1px solid #f8f8f0 !important;}
 
 .cm-s-dark span.cm-comment {color: #75715e;}

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -43,6 +43,10 @@ body[theme="light"] #sidebar .mdc-icon-button:focus {
   opacity: .87;
 }
 
+body[theme="light"] #title-filename {
+  color: #5f6368;
+}
+
 body[theme="light"] .mdc-switch:not(.mdc-switch--checked) .mdc-switch__thumb {
   border-color: rgb(236, 236, 236);
 }
@@ -81,6 +85,7 @@ body[theme="light"] .mdc-radio .mdc-radio__native-control:enabled:not(:checked)+
 .cm-s-light .cm-quote {color: #090;}
 .cm-s-light .cm-hr {color: #999;}
 .cm-s-light .cm-link {color: #00c;}
+.cm-s-light .CodeMirror-linenumber {color: #5f6368;}
 
 body[theme="light"] div.CodeMirror span.CodeMirror-matchingbracket {
   color: inherit !important;


### PR DESCRIPTION
Update both of these to `cros-text-color-secondary`: #5f6368 in light. #bdc1c6 in dark.

Also delete some seemingly unused CSS variables from `app.css`. They were added in https://github.com/GoogleChromeLabs/text-app/commit/2a8bc741281c87a7a10bba2000928a01464ff268

Looks like in light mode:
![image](https://user-images.githubusercontent.com/15045948/152289319-a7bb8c4d-fc9f-4253-a483-1e283af98258.png)