### PR TITLE
Add localized UI text for the use device theme setting

### DIFF
--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -63,6 +63,10 @@
     "message": "Standard",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Brug enhedens tema",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Lys",
     "description": "The text of the light Option Theme."

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -63,6 +63,10 @@
     "message": "Standard",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Gerätedesign verwenden",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Hell",
     "description": "The text of the light Option Theme."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -63,6 +63,10 @@
     "message": "Default",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Use device theme",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Light",
     "description": "The text of the light Option Theme."

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -63,6 +63,10 @@
     "message": "Default",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Use device theme",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Light",
     "description": "The text of the light Option Theme."

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -63,6 +63,10 @@
     "message": "Predeterminado",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Usar el tema del dispositivo",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Claro",
     "description": "The text of the light Option Theme."

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -63,6 +63,10 @@
     "message": "Predeterminado",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Usar tema del dispositivo",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Claro",
     "description": "The text of the light Option Theme."

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -63,6 +63,10 @@
     "message": "Oletus",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Käytä laitteen teemaa",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Vaalea",
     "description": "The text of the light Option Theme."

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -63,6 +63,10 @@
     "message": "Par défaut",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Utiliser le thème de l'appareil",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Clair",
     "description": "The text of the light Option Theme."

--- a/_locales/fr_CA/messages.json
+++ b/_locales/fr_CA/messages.json
@@ -63,6 +63,10 @@
     "message": "Par défaut",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Même thème que l'appareil",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Clair",
     "description": "The text of the light Option Theme."

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -63,6 +63,10 @@
     "message": "Predefinito",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Usa tema del dispositivo",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Chiaro",
     "description": "The text of the light Option Theme."

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -63,6 +63,10 @@
     "message": "デフォルト",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "デバイスのテーマを使用する",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "明るい",
     "description": "The text of the light Option Theme."

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -63,6 +63,10 @@
     "message": "기본 테마",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "기기 테마 사용",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "밝게",
     "description": "The text of the light Option Theme."

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -63,6 +63,10 @@
     "message": "Standaard",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Apparaatthema gebruiken",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Licht",
     "description": "The text of the light Option Theme."

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -63,6 +63,10 @@
     "message": "Standard",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Bruk temaet fra enheten",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Lyst",
     "description": "The text of the light Option Theme."

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -63,6 +63,10 @@
     "message": "Domyślny",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Użyj motywu urządzenia",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Jasny",
     "description": "The text of the light Option Theme."

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -63,6 +63,10 @@
     "message": "Padrão",
     "description": "O texto da Opção de Tema padrão."
   },
+  "deviceThemeOption": {
+    "message": "Usar o tema do dispositivo",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Claro",
     "description": "O texto da Opção de Tema claro."

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -63,6 +63,10 @@
     "message": "По умолчанию",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Как на устройстве",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Светлая",
     "description": "The text of the light Option Theme."

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -63,6 +63,10 @@
     "message": "Standard",
     "description": "The text of the default Option Theme."
   },
+  "deviceThemeOption": {
+    "message": "Använd enhetens tema",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "lightThemeOption": {
     "message": "Ljust",
     "description": "The text of the light Option Theme."

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -27,6 +27,10 @@
     "description": "The text of the default Option Theme.",
     "message": "默认"
   },
+  "deviceThemeOption": {
+    "message": "使用设备主题",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "errorTitle": {
     "description": "The error text displayed in the filename title bar.",
     "message": "错误"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -27,6 +27,10 @@
     "description": "The text of the default Option Theme.",
     "message": "預設"
   },
+  "deviceThemeOption": {
+    "message": "使用裝置主題",
+    "description": "The label on a radio button that lets the user configure the app to use their device's color theme. This changes the appearance of the app."
+  },
   "errorTitle": {
     "description": "The error text displayed in the filename title bar.",
     "message": "錯誤"

--- a/js/app.js
+++ b/js/app.js
@@ -35,7 +35,7 @@ TextApp.prototype.init = function() {
   this.enableSystemTheme_ =
       parseInt(navigator.appVersion.match(/Chrome\/(\d+)\./)[1], 10) >= 103;
 
-  this.settings_ = new Settings();
+  this.settings_ = new Settings(this.enableSystemTheme_);
   // Editor is initalised after settings are ready.
   this.editor_ = null;
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,7 +1,10 @@
 /**
  * @constructor
+ *
+ * @param {boolean} enableSystemTheme Whether or not to enable the system theme
+ *     feature.
  */
-function Settings() {
+function Settings(enableSystemTheme) {
   this.ready_ = false;
   this.settings_ = {};
   var storageKeys = {};
@@ -14,6 +17,14 @@ function Settings() {
   chrome.storage.onChanged.addListener(this.onChanged_.bind(this));
   chrome.runtime.onInstalled.addListener(this.removeOldSettings_.bind(this));
   this.storage_.get(storageKeys, this.getSettingsCallback_.bind(this));
+
+  if (enableSystemTheme) {
+    // Replace the default theme option UI text with device theme option.
+    document.querySelector('label[for="setting-theme-default"]')
+      .setAttribute('i18n-content', 'DeviceThemeOption');
+    // Translate the settings labels again.
+    i18nTemplate.process(document.getElementById('settings-list'));
+  }
 }
 
 /**


### PR DESCRIPTION
The previous PR that added the functionality and version check for the feature: https://github.com/GoogleChromeLabs/text-app/pull/553

This PR makes the UI text change depending on whether or not it's enabled.

Behavior when disabled (version < 103):

 * The Default theme is a black side nav and a white editor.
 * The radio button's label is "Default".

Behavior when enabled (version >= 103):

 * The Default theme is dark or light depending on the system's preferred color scheme.
 * The radio button's label is "Use device theme".

Note that `i18nTemplate.process` is used in one other place to translate the entire document:
https://github.com/GoogleChromeLabs/text-app/blob/588da50d131a226581ead33ffa0719f8eb68a7f4/js/i18n-template.js