### PR TITLE
Bump version from 0.6 to 0.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Text Dev",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
-  "version": "0.6",
+  "version": "0.7",
   "icons": {
     "16": "icon/16x16.png",
     "32": "icon/32x32.png",


### PR DESCRIPTION
This should have the 0.7 tag

https://github.com/GoogleChromeLabs/text-app/releases/tag/v0.7