### PR TITLE
Add keyboard navigation and visible focus to side nav

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -93,9 +93,15 @@ img {
 }
 
 #sidebar h2 {
+  align-items: center;
+  display: flex;
   font: 500 13px "Roboto", sans-serif;
   letter-spacing: 1.2px;
+  margin: 4px 8px;
+  min-height: var(--tab-height);
+  padding: 0 16px;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
 #sidebar hr {
@@ -110,29 +116,30 @@ img {
   list-style-type: none;
 }
 
-#sidebar h2,
-#sidebar li,
-#sidebar .mdc-form-field {
-  align-items: center;
-  display: flex;
-  min-height: var(--tab-height);
-  margin: 4px 8px;
-  padding: 0 16px;
-  -webkit-user-select: none;
-  white-space: nowrap;
-}
-
-#sidebar li,
-#sidebar .mdc-form-field {
+#sidebar li {
   border-radius: 100px;
-  cursor: pointer;
+  margin: 4px 8px;
 }
 
-#sidebar li:hover,
-#sidebar .mdc-form-field:hover,
-#tabs-list li.active:hover {
-  background-color: var(--dark-highlight-color);
-  color: #fff;
+.sidebar-button {
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  border-radius: 100px;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  margin: 0;
+  min-height: var(--tab-height);
+  padding: 0 16px;
+  text-align: start;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.sidebar-button:focus-visible {
+  outline: 2px solid -webkit-focus-ring-color;
 }
 
 #sidebar input {
@@ -178,39 +185,45 @@ img {
   align-items: center;
   display: flex;
   flex-direction: row;
+  position: relative;
 }
 
-#tabs-list li.active {
+#tabs-list li.active,
+#tabs-list li.active:hover {
   background-color: var(--dark-accent-color);
 }
 
-#tabs-list li .filename {
+#tabs-list .filename {
   display: inline;
   flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-#tabs-list li.unsaved .filename:after {
+#tabs-list .filename.unsaved:after {
   content: " *";
 }
 
-#tabs-list li .close {
+#tabs-list li > .close {
   display: none;
   font-size: 20px;
-  height: 100%;
+  height: var(--tab-height);
   justify-content: center;
   min-width: var(--tab-height);
   padding: 0;
   width: var(--tab-height);
 }
 
-#tabs-list li:hover {
-  padding-right: 0;
+#tabs-list li:hover > .close {
+  align-items: center;
+  display: flex;
+  position: absolute;
+  right: 8px;
+  top: 0;
 }
 
-#tabs-list li:hover .close {
-  display: flex;
+#tabs-list li:hover > .filename {
+  padding-right: var(--tab-height);
 }
 
 #file-tabs-menu {
@@ -245,14 +258,30 @@ img {
 
 #settings-list li,
 #settings-list .mdc-form-field {
+  align-items: center;
   background-color: inherit;
+  border-radius: 100px;
+  cursor: pointer;
   -webkit-box-flex: 1.0;
   -webkit-box-orient: horizontal;
   -webkit-box-align: end;
   display: -webkit-flex;
-  padding-right: 0;
+  margin: 4px 8px;
+  min-height: var(--tab-height);
+  padding: 0;
   word-break: break-all;
   word-wrap: break-word;
+}
+
+#settings-list li:focus-within,
+#settings-list .mdc-form-field:focus-within {
+  outline: 2px solid -webkit-focus-ring-color;
+}
+
+#sidebar li:hover,
+#settings-list .mdc-form-field:hover {
+  background-color: var(--dark-highlight-color);
+  color: #fff;
 }
 
 .mdc-form-field {
@@ -273,14 +302,15 @@ img {
 
 #settings-list label {
   align-items: center;
+  box-sizing: border-box;
   cursor: pointer;
   display: flex;
   flex: 1;
-  height: 100%;
   margin: 0;
   max-width: calc(100% - var(--settings-input-width));
+  min-height: var(--tab-height);
   overflow: hidden;
-  padding: 4px 0;
+  padding: 4px 0 4px 16px;
   text-overflow: ellipsis;
   word-break: break-word;
   white-space: normal;

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -12,7 +12,7 @@ body[theme="light"] #sidebar hr {
 }
 
 body[theme="light"] #sidebar li:hover,
-body[theme="light"] #sidebar .mdc-form-field:hover {
+body[theme="light"] #settings-list .mdc-form-field:hover {
   background-color: var(--light-highlight-color);
   color: #000;
 }
@@ -26,12 +26,9 @@ body[theme="light"] #settings-list input[type="text"]:focus {
   outline: none;
 }
 
-body[theme="light"] #tabs-list li.active {
+body[theme="light"] #tabs-list li.active,
+body[theme="light"] #tabs-list li.active:hover {
   background-color: var(--light-accent-color);
-}
-
-body[theme="light"] #sidebar #tabs-list li:hover {
-  background-color: var(--light-highlight-color);
 }
 
 body[theme="light"] #sidebar .mdc-icon-button {

--- a/index.html
+++ b/index.html
@@ -21,10 +21,34 @@
         <hr>
 
         <ul id="file-menu">
-          <li id="file-menu-new"><div i18n-content="fileMenuNew"></div></li>
-          <li id="file-menu-open"><div i18n-content="fileMenuOpen"></div></li>
-          <li id="file-menu-save"><div i18n-content="fileMenuSave"></div></li>
-          <li id="file-menu-saveas"><div i18n-content="fileMenuSaveas"></div></li>
+          <li>
+            <button
+                id="file-menu-new"
+                class="sidebar-button"
+                i18n-content="fileMenuNew">
+            </button>
+          </li>
+          <li>
+            <button
+                id="file-menu-open"
+                class="sidebar-button"
+                i18n-content="fileMenuOpen">
+            </button>
+          </li>
+          <li>
+            <button
+                id="file-menu-save"
+                class="sidebar-button"
+                i18n-content="fileMenuSave">
+            </button>
+          </li>
+          <li>
+            <button
+                id="file-menu-saveas"
+                class="sidebar-button"
+                i18n-content="fileMenuSaveas">
+            </button>
+          </li>
         </ul>
 
         <hr>
@@ -35,7 +59,13 @@
 
         <hr>
         <ul class="settings-switch-ul">
-          <li id="open-settings"><div i18n-content="menuSettings"></div></li>
+          <li>
+            <button
+                id="open-settings"
+                class="sidebar-button"
+                i18n-content="menuSettings">
+            </button>
+          </li>
         </ul>
       </div>
       <div id="settings-menu">
@@ -163,7 +193,9 @@
         </div>
         <hr>
         <ul class="settings-switch-ul">
-          <li id="close-settings"><div i18n-content="closeSettings"></div></li>
+          <li>
+            <button id="close-settings" class="sidebar-button" i18n-content="closeSettings"></button>
+          </li>
         </ul>
       </div>
     </div>

--- a/js/controllers/menu.js
+++ b/js/controllers/menu.js
@@ -27,10 +27,10 @@ MenuController.prototype.addNewTab_ = function(e, tab) {
   const id = tab.getId();
   const tabElement = document.createElement('li');
   tabElement.setAttribute('draggable', 'true');
-  tabElement.id = 'tab' + id;
-  const filenameElement = document.createElement('div');
+  const filenameElement = document.createElement('button');
+  filenameElement.id = 'tab' + id;
   filenameElement.textContent = tab.getName();
-  filenameElement.className = 'filename';
+  filenameElement.className = 'filename sidebar-button';
   tabElement.appendChild(filenameElement);
   const closeElement = document.createElement('button');
   closeElement.textContent = 'close';
@@ -48,7 +48,7 @@ MenuController.prototype.addNewTab_ = function(e, tab) {
       'dragend', (event) => { this.onDragEnd_($(tabElement), event)});
   tabElement.addEventListener(
       'drop', (event) => { this.onDrop_(event); });
-  tabElement.addEventListener(
+  filenameElement.addEventListener(
       'click', () => { this.tabButtonClicked_(id); });
   closeElement.addEventListener(
       'click', (event) => { this.closeTab_(event, id); });
@@ -70,8 +70,10 @@ MenuController.prototype.onDrop_ = function(e) {
 
 MenuController.prototype.onDragOver_ = function(overItem, e) {
   e.preventDefault();
-  if (!this.dragItem_ || overItem.attr('id') === this.dragItem_.attr('id'))
+  if (!this.dragItem_ || overItem.find('.filename').attr('id')
+      === this.dragItem_.find('.filename').attr('id')) {
     return;
+  }
 
   if (this.dragItem_.index() < overItem.index()) {
     overItem.after(this.dragItem_);
@@ -82,12 +84,12 @@ MenuController.prototype.onDragOver_ = function(overItem, e) {
 };
 
 MenuController.prototype.onTabRenamed = function(e, tab) {
-  $('#tab' + tab.getId() + ' .filename').text(tab.getName());
+  $('#tab' + tab.getId() + '.filename').text(tab.getName());
   this.tabs_.modeAutoSet(tab);
 };
 
 MenuController.prototype.onTabPathChange = function(e, tab) {
-  $('#tab' + tab.getId() + ' .filename').attr('title', tab.getPath());
+  $('#tab' + tab.getId() + '.filename').attr('title', tab.getPath());
 };
 
 MenuController.prototype.onTabChange = function(e, tab) {
@@ -95,7 +97,7 @@ MenuController.prototype.onTabChange = function(e, tab) {
 };
 
 MenuController.prototype.onTabClosed = function(e, tab) {
-  $('#tab' + tab.getId()).remove();
+  $('#tab' + tab.getId()).parent().remove();
 };
 
 MenuController.prototype.onTabSave = function(e, tab) {
@@ -103,8 +105,10 @@ MenuController.prototype.onTabSave = function(e, tab) {
 };
 
 MenuController.prototype.onSwitchTab = function(e, tab) {
-  $('#tabs-list li.active').removeClass('active');
-  $('#tab' + tab.getId()).addClass('active');
+  // Add the .active class to the <li> wrapping the tab button so the <li> gets
+  // the active background-color style.
+  $('#tabs-list .active').removeClass('active');
+  $('#tab' + tab.getId()).parent().addClass('active');
 };
 
 MenuController.prototype.newTab_ = function() {


### PR DESCRIPTION
Add `<button>` elements to all the `<li>` in the side nav. These can be tabbed to. And they can be activated using Space/Enter.

Previously, nothing in the side nav was a tab stop except for the "Close file" buttons, which can only be tabbed to when you're also hovering over a file tab. And the list items only had click event listeners, so they couldn't be activated using the keyboard.

The visible focus looks like an orange outline:
![image](https://user-images.githubusercontent.com/15045948/198217865-386ff9ec-30f4-4c50-905d-0ab93f7a93c7.png)

The visible focus for the inputs in the Settings page also appear on `focus`, not just `focus-visible`. This is less ideal than `focus-visible` only because you also see it when using your mouse, but it was simpler to implement.
