### PR TITLE
Add Ctrl E shortcut to focus the file tab in the side nav

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -135,7 +135,8 @@ TextApp.prototype.initControllers_ = function() {
   this.windowController_ =
       new WindowController(this.editor_, this.settings_, this.tabs_);
   this.hotkeysController_ = new HotkeysController(
-      this.windowController_, this.tabs_, this.editor_, this.settings_);
+      this.windowController_, this.tabs_, this.editor_, this.settings_,
+      this.settingsController_);
   this.searchController_ = new SearchController(this.editor_.getSearch());
 };
 /**

--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -1,11 +1,13 @@
 /**
  * @constructor
  */
-function HotkeysController(windowController, tabs, editor, settings) {
+function HotkeysController(windowController, tabs, editor, settings,
+    settingsController) {
   this.windowController_ = windowController;
   this.tabs_ = tabs;
   this.editor_ = editor;
   this.settings_ = settings;
+  this.settingsController_ = settingsController;
 
   this.ZOOM_IN_FACTOR = 9 / 8;
   this.ZOOM_OUT_FACTOR = 8 / 9;
@@ -94,6 +96,14 @@ HotkeysController.prototype.onKeydown_ = function(e) {
       case '_':
         var fontSize = this.settings_.get('fontsize');
         this.settings_.set('fontsize', fontSize * this.ZOOM_OUT_FACTOR);
+        return false;
+
+      case 'e':
+        // Focus the current file's tab in the sidebar. This includes opening
+        // the sidebar and closing settings if needed.
+        this.windowController_.openSidebar();
+        this.settingsController_.closeSettings();
+        $('#tab' + this.tabs_.getCurrentTab().getId()).focus();
         return false;
 
       default:

--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -40,6 +40,15 @@ HotkeysController.prototype.onKeydown_ = function(e) {
         }
         return false;
 
+      case 'e':
+      case 'E':
+        // Focus the current file's tab in the sidebar. This includes opening
+        // the sidebar and closing settings if needed.
+        this.windowController_.openSidebar();
+        this.settingsController_.closeSettings();
+        $('#tab' + this.tabs_.getCurrentTab().getId()).focus();
+        return false;
+
       case 'f':
       case 'F':
         document.getElementById('search-input').focus();
@@ -96,14 +105,6 @@ HotkeysController.prototype.onKeydown_ = function(e) {
       case '_':
         var fontSize = this.settings_.get('fontsize');
         this.settings_.set('fontsize', fontSize * this.ZOOM_OUT_FACTOR);
-        return false;
-
-      case 'e':
-        // Focus the current file's tab in the sidebar. This includes opening
-        // the sidebar and closing settings if needed.
-        this.windowController_.openSidebar();
-        this.settingsController_.closeSettings();
-        $('#tab' + this.tabs_.getCurrentTab().getId()).focus();
         return false;
 
       default:

--- a/js/controllers/settings.js
+++ b/js/controllers/settings.js
@@ -15,8 +15,8 @@ function SettingsController(settings) {
 
   this.addInputListeners_();
 
-  $('#open-settings').click(this.open_.bind(this));
-  $('#close-settings').click(this.close_.bind(this));
+  $('#open-settings').click(this.openSettings_.bind(this));
+  $('#close-settings').click(this.closeSettings.bind(this));
 }
 
 /**
@@ -40,11 +40,12 @@ SettingsController.prototype.addInputListeners_ = function() {
   }
 };
 
-SettingsController.prototype.open_ = function() {
+SettingsController.prototype.openSettings_ = function() {
   $('#sidebar').addClass('open-settings');
 };
 
-SettingsController.prototype.close_ = function() {
+/** Close the settings page if it was open. */
+SettingsController.prototype.closeSettings = function() {
   $('#sidebar').removeClass('open-settings');
 };
 

--- a/js/controllers/settings.js
+++ b/js/controllers/settings.js
@@ -42,11 +42,15 @@ SettingsController.prototype.addInputListeners_ = function() {
 
 SettingsController.prototype.openSettings_ = function() {
   $('#sidebar').addClass('open-settings');
+  // Focus the first setting.
+  $('#settings-list input:first').focus();
 };
 
 /** Close the settings page if it was open. */
 SettingsController.prototype.closeSettings = function() {
   $('#sidebar').removeClass('open-settings');
+  // Focus the button that reopens settings.
+  $('#open-settings').focus();
 };
 
 SettingsController.prototype.showAll_ = function() {

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -138,9 +138,6 @@ WindowController.prototype.toggleSidebar_ = function() {
         .attr('title', chrome.i18n.getMessage('closeSidebarButton'));
   }
   this.editor_.focus();
-  setTimeout(function() {
-    $.event.trigger('resize');
-  }, 200);
 };
 
 WindowController.prototype.onLoadingFile = function(e) {

--- a/js/controllers/window.js
+++ b/js/controllers/window.js
@@ -122,6 +122,16 @@ WindowController.prototype.setAlwaysOnTop = function(isAlwaysOnTop) {
   window.chrome.app.window.current().setAlwaysOnTop(isAlwaysOnTop);
 };
 
+/** Opens the sidebar if it is closed. */
+WindowController.prototype.openSidebar = function() {
+  if (this.settings_.get('sidebaropen')) return;
+  this.settings_.set('sidebaropen', true);
+    $('#sidebar').css('width', this.settings_.get('sidebarwidth') + 'px');
+    $('#sidebar').css('border-right-width', '2px');
+    $('#toggle-sidebar')
+        .attr('title', chrome.i18n.getMessage('closeSidebarButton'));
+};
+
 WindowController.prototype.toggleSidebar_ = function() {
   // FIXME: Move this to css where possible (toggle code)
   if (this.settings_.get('sidebaropen')) {
@@ -131,11 +141,7 @@ WindowController.prototype.toggleSidebar_ = function() {
     $('#toggle-sidebar')
         .attr('title', chrome.i18n.getMessage('openSidebarButton'));
   } else {
-    this.settings_.set('sidebaropen', true);
-    $('#sidebar').css('width', this.settings_.get('sidebarwidth') + 'px');
-    $('#sidebar').css('border-right-width', '2px');
-    $('#toggle-sidebar')
-        .attr('title', chrome.i18n.getMessage('closeSidebarButton'));
+    this.openSidebar();
   }
   this.editor_.focus();
 };


### PR DESCRIPTION
The Ctrl E shortcut focuses the tab in the side nav corresponding to the currently open editor. It also opens the sidebar and closes settings if needed.
Ctrl Shift E does the same thing.
The choice of key was inspired by Visual Studio Code, which has:

 * Ctrl E: Search file by name
 * Ctrl Shift E: Focus the file Explorer

Also set focus when opening and closing the settings page. Previously it lost focus.

And remove the `resize` event because it is unused.