### PR TITLE
Change "case sensitive" hotkeys to check if "Shift" was pressed.

### DIFF
--- a/js/controllers/hotkeys.js
+++ b/js/controllers/hotkeys.js
@@ -55,11 +55,12 @@ HotkeysController.prototype.onKeydown_ = function(e) {
         return false;
 
       case 'n':
-        this.tabs_.newTab();
-        return false;
-
       case 'N':
-        this.tabs_.newWindow();
+        if (e.shiftKey) {
+          this.tabs_.newWindow();
+        } else {
+          this.tabs_.newTab();
+        }
         return false;
 
       case 'o':
@@ -83,11 +84,12 @@ HotkeysController.prototype.onKeydown_ = function(e) {
         return false;
 
       case 'w':
-        this.tabs_.closeCurrent();
-        return false;
-
       case 'W':
-        this.windowController_.close();
+        if (e.shiftKey) {
+          this.windowController_.close();
+        } else {
+          this.tabs_.closeCurrent();
+        }
         return false;
 
       case '0':


### PR DESCRIPTION
The hotkey for "Close tab" was assigned to "ctrl + w", while "Close window" was assigned to "ctrl + W". When Caps lock is turned on, pressing "Ctrl + w" would close the window instead.

This is because the logic looks at whether the key press was upper/lower case. Similarly, this is affecting the "New tab" and "New window" hotkeys. 

This pull request fixes the above hotkeys by checking if the Shift key was pressed to ensure consistent behavior despite the Caps lock state.