### PR TITLE
Add navigation role to sidebar and radiogroup role to the Themes setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <div id="window-container">
     <div id="sidebar">
       <div id="sidebar-resizer"></div>
-      <div id="file-tabs-menu">
+      <div id="file-tabs-menu" role="navigation">
         <h1>Text</h1>
 
         <hr>
@@ -68,7 +68,7 @@
           </li>
         </ul>
       </div>
-      <div id="settings-menu">
+      <div id="settings-menu" role="navigation">
         <h1 i18n-content="menuSettings"></h1>
         <hr>
         <div id="settings-container">

--- a/index.html
+++ b/index.html
@@ -156,8 +156,8 @@
                 </div>
               </div>
             </li>
-            <div class="group">
-              <h2 i18n-content="themeSetting"></h2>
+            <div class="group" role="radiogroup" aria-labelledby="setting-theme-heading">
+              <h2 id="setting-theme-heading" i18n-content="themeSetting"></h2>
               <div class="mdc-form-field">
                 <label for="setting-theme-default" i18n-content="DefaultThemeOption"></label>
                 <div class="mdc-radio">


### PR DESCRIPTION
When using a screen reader such as ChromeVox:

 * The `navigation` role lets you jump between the top of the sidebar and the editor. These are the aria landmarks.
 * The `radiogroup` role makes the screen reader announce the label of the group ("Themes") and
the fact that it's a radio group when tabbing into the group.
   * It also announces "Exited Radio button group" when you tab out.
