### PR TITLE
Add Help section with Shortcuts button to open HC article.

### DIFF
--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -23,6 +23,10 @@
     "message": "Indstillinger",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Genveje",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Skriftstørrelse",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Mørk",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Hjælp",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Tilbage",

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -23,6 +23,10 @@
     "message": "Einstellungen",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Tastenkombinationen",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Schriftgröße",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Dunkel",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Hilfe",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Zurück",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,10 @@
     "message": "Settings",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Shortcuts",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Font size",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Dark",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Help",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Back",

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -23,6 +23,10 @@
     "message": "Settings",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Shortcuts",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Font size",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Dark",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Help",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Back",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -23,6 +23,10 @@
     "message": "Ajustes",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Combinaciones de teclas",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Tamaño de fuente",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Oscuro",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Ayuda",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Atrás",

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -23,6 +23,10 @@
     "message": "Configuración",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Combinaciones de teclas",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Tamaño de fuente",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Oscuro",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Ayuda",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Atrás",

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -23,6 +23,10 @@
     "message": "Asetukset",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Pikanäppäimet",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Kirjasinkoko",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Tumma",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Ohje",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Takaisin",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -23,6 +23,10 @@
     "message": "Paramètres",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Raccourcis",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Taille de police",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Foncé",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Aide",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Retour",

--- a/_locales/fr_CA/messages.json
+++ b/_locales/fr_CA/messages.json
@@ -23,6 +23,10 @@
     "message": "Paramètres",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Raccourcis",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Taille de police",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Foncé",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Aide",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Retour",

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -23,6 +23,10 @@
     "message": "Impostazioni",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Scorciatoie",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Dimensioni carattere",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Scuro",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Guida",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Indietro",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -23,6 +23,10 @@
     "message": "設定",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "ショートカット",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "フォントサイズ",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "暗い",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "ヘルプ",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "戻る",

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -23,6 +23,10 @@
     "message": "설정",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "바로가기",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "글꼴 크기",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "어둡게",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "도움말",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "뒤로",

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -23,6 +23,10 @@
     "message": "Instellingen",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Snelkoppelingen",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Lettergrootte",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Donker",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Help",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Terug",

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -23,6 +23,10 @@
     "message": "Innstillinger",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Snarveier",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Skriftstørrelse",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Mørkt",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Hjelp",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Tilbake",

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -23,6 +23,10 @@
     "message": "Ustawienia",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Skróty",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Rozmiar czcionki",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Ciemny",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Pomoc",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Wstecz",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -23,6 +23,10 @@
     "message": "Configurações",
     "description": "O texto do Menu 'Configurações'."
   },
+  "menuShortcuts": {
+    "message": "Atalhos",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Tamanho da fonte",
     "description": "O texto das configurações 'Tamanho da fonte'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Escuro",
     "description": "O texto da Opção de Tema escuro."
+  },
+  "helpSection": {
+    "message": "Ajuda",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Voltar",

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -23,6 +23,10 @@
     "message": "Настройки",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Сочетания клавиш",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Размер шрифта",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Тёмная",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Справка",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Назад",

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -23,6 +23,10 @@
     "message": "Inställningar",
     "description": "The text of the Menu 'Settings'."
   },
+  "menuShortcuts": {
+    "message": "Genvägar",
+    "description": "The text of the Menu 'Shortcuts'."
+  },
   "fontsizeSetting": {
     "message": "Teckenstorlek",
     "description": "The text of the settings 'Font size'."
@@ -74,6 +78,10 @@
   "darkThemeOption": {
     "message": "Mörkt",
     "description": "The text of the dark Option Theme."
+  },
+  "helpSection": {
+    "message": "Hjälp",
+    "description": "Title for a section with useful links to help articles."
   },
   "closeSettings": {
     "message": "Tillbaka",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -23,6 +23,10 @@
     "description": "The text of the dark Option Theme.",
     "message": "黑暗"
   },
+  "helpSection": {
+    "message": "帮助",
+    "description": "Title for a section with useful links to help articles."
+  },
   "defaultThemeOption": {
     "description": "The text of the default Option Theme.",
     "message": "默认"
@@ -78,6 +82,10 @@
   "menuSettings": {
     "description": "The text of the Menu 'Settings'.",
     "message": "设置"
+  },
+  "menuShortcuts": {
+    "message": "快捷键",
+    "description": "The text of the Menu 'Shortcuts'."
   },
   "minimizeButton": {
     "description": "The button text to minimize the app window.",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -23,6 +23,10 @@
     "description": "The text of the dark Option Theme.",
     "message": "深色"
   },
+  "helpSection": {
+    "message": "說明",
+    "description": "Title for a section with useful links to help articles."
+  },
   "defaultThemeOption": {
     "description": "The text of the default Option Theme.",
     "message": "預設"
@@ -78,6 +82,10 @@
   "menuSettings": {
     "description": "The text of the Menu 'Settings'.",
     "message": "設定"
+  },
+  "menuShortcuts": {
+    "message": "快速鍵",
+    "description": "The text of the Menu 'Shortcuts'."
   },
   "minimizeButton": {
     "description": "The button text to minimize the app window.",

--- a/css/app.css
+++ b/css/app.css
@@ -484,6 +484,14 @@ header.search-active .search-navigation-button {
   content: " *";
 }
 
+#open-shortcuts {
+  justify-content: space-between;
+}
+
+#open-shortcuts .icon {
+  font-size: 20px;
+}
+
 #window-minimize {
   /* Move the 'remove' icon down so it looks like a minimize icon */
   padding-top: 18px;

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -12,6 +12,7 @@ body[theme="dark"] .search-container {
 }
 
 body[theme="dark"] #search-input,
+body[theme="dark"] .icon,
 body[theme="dark"] .mdc-icon-button {
   color: #EBEBEB;
 }

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -31,6 +31,7 @@ body[theme="light"] #tabs-list li.active:hover {
   background-color: var(--light-accent-color);
 }
 
+body[theme="light"] #sidebar .icon,
 body[theme="light"] #sidebar .mdc-icon-button {
   color: #000;
   opacity: .54;

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
                 </div>
               </div>
             </div>
-            <div class="group" role="radiogroup" aria-labelledby="setting-help-heading">
+            <div class="group" aria-labelledby="setting-help-heading">
               <h2 id="setting-help-heading" i18n-content="helpSection"></h2>
               <div class="mdc-form-field">
                 <button

--- a/index.html
+++ b/index.html
@@ -189,6 +189,17 @@
                 </div>
               </div>
             </div>
+            <div class="group" role="radiogroup" aria-labelledby="setting-help-heading">
+              <h2 id="setting-help-heading" i18n-content="helpSection"></h2>
+              <div class="mdc-form-field">
+                <button
+                    id="open-shortcuts"
+                    class="sidebar-button">
+                  <span i18n-content="menuShortcuts"></span>
+                  <span class="icon material-icons">launch</span>
+                </button>
+              </div>
+            </div>
           </ul>
         </div>
         <hr>

--- a/js/controllers/menu.js
+++ b/js/controllers/menu.js
@@ -132,7 +132,7 @@ MenuController.prototype.saveas_ = function() {
   return false;
 };
 
-MenuController.prototype.openShortcuts_ = function(e, tab) {
+MenuController.prototype.openShortcuts_ = function() {
   window.open('https://support.google.com/chromebook/answer/183101#textapp', '_blank');
   return false;
 };

--- a/js/controllers/menu.js
+++ b/js/controllers/menu.js
@@ -8,6 +8,7 @@ function MenuController(tabs) {
   $('#file-menu-open').click(this.open_.bind(this));
   $('#file-menu-save').click(this.save_.bind(this));
   $('#file-menu-saveas').click(this.saveas_.bind(this));
+  $('#open-shortcuts').click(this.openShortcuts_.bind(this));
   $(document).bind('newtab', this.addNewTab_.bind(this));
   $(document).bind('switchtab', this.onSwitchTab.bind(this));
   $(document).bind('tabchange', this.onTabChange.bind(this));
@@ -128,6 +129,11 @@ MenuController.prototype.save_ = function() {
 
 MenuController.prototype.saveas_ = function() {
   this.tabs_.saveAs();
+  return false;
+};
+
+MenuController.prototype.openShortcuts_ = function(e, tab) {
+  window.open('https://support.google.com/chromebook/answer/183101#textapp', '_blank');
   return false;
 };
 


### PR DESCRIPTION
I've added the Help section at the end of the Settings section in the Side Menu.

Button links to https://support.google.com/chromebook/answer/183101#textapp