### PR TITLE
Fix cursor type when hovering text to be the I-beam

### DIFF
--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -72,6 +72,9 @@ function EditorCodeMirror(editorElement, settings) {
     ".cm-nonmatchingBracket": {
       backgroundColor: "inherit !important",
     },
+    ".cm-line": {
+      cursor: "auto",
+    }
   };
 
   this.lightTheme_ = CodeMirror.view.EditorView.theme(themeStyles, {dark: false});


### PR DESCRIPTION
Chrome Apps' default CSS styling sets `cursor:default` on body. CMv6 doesn't override this so we end up with the normal pointer when hovering text. Manually set `cursor:auto` on the text area of the editor so we get the correct cursor on text, and match previous versions of the Text App so blank space below the last line of a document remain with the default pointer.