### PR TITLE
Increase minimum history limit from 100 to 10000

### DIFF
--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -178,7 +178,9 @@ EditorCodeMirror.prototype.newState = function(opt_content) {
   return CodeMirror.state.EditorState.create({
     doc: opt_content || '',
     extensions: [
-      CodeMirror.commands.history(),
+      CodeMirror.commands.history({
+        minDepth: 10000,
+      }),
       CodeMirror.view.drawSelection(),
       CodeMirror.language.bracketMatching(),
       this.langCompartment_.of(CodeMirror.lang.javascript()),


### PR DESCRIPTION
This changed from CMv5's default of 200 to CMv6's default of 100. Having a large history seems pretty cheap, so set this to a very large value.