### PR TITLE
Optimize find performance

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -23,17 +23,27 @@ Search.prototype.computeResultsCount_ = function(query) {
     return;
   }
 
-  const cursor = this.editorView_.state.selection.main.anchor;
+  let cursor = this.editorView_.state.selection.main.anchor;
 
-  let text = this.editorView_.state.doc;
-  let search = new window.CodeMirror.search.SearchCursor(
-    text, query, 0, text.length, (s) => s.toLowerCase());
+  for (let line of this.editorView_.state.doc.iterLines()) {
+    const lowerLine = line.toLowerCase();
+    let pos = 0;
+    while (true) {
+      pos = lowerLine.indexOf(query, pos);
+      if (pos < 0) {
+        break;
+      }
 
-  for (let value of search) {
-    this.resultsCount_++;
-    if (value.from < cursor) {
-      this.index_++;
+      this.resultsCount_++;
+      if (pos < cursor) {
+        this.index_++;
+      }
+      // Don't count overlapping matches.
+      pos += query.length;
     }
+
+    // This is correct even when the loaded file uses \r\n.
+    cursor -= lowerLine.length + 1;
   }
 };
 


### PR DESCRIPTION
The current find impl is much slower (~30x on large documents) than the previous one, mainly due to using the SearchCursor to count matches instead of manually counting. It's preferable to use SearchCursor as it gives us confidence our counting will match CM's counting, but for performance revert back to manually counting.

There is still an off-by-one issue present with overlapping matches (e.g. "a|aaa", search "aa" and go to previous match), but this was already present in the previous implementation.